### PR TITLE
Fixes for CTDC-966 and CTDC-1048

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -1985,6 +1985,20 @@ export const tabContainers = [
         role: cellTypes.DISPLAY,
       },
       {
+        dataField: 'association',
+        header: 'Association',
+        display: true,
+        tooltipText: 'sort',
+        role: cellTypes.DISPLAY,
+      },
+      {
+        dataField: 'data_file_description',
+        header: 'Description',
+        display: true,
+        tooltipText: 'sort',
+        role: cellTypes.DISPLAY,
+      },
+      {
         dataField: 'data_file_uuid', // This need to left empty if no data need to be displayed before file download icon
         header: 'Access',
         display: true,
@@ -2016,20 +2030,6 @@ export const tabContainers = [
           iconFilePreview: previewLarge,
           toolTipTextFilePreview: 'Because of its size and/or format, this file must be accessed via the My Files workflow',
         },
-        tooltipText: 'sort',
-        role: cellTypes.DISPLAY,
-      },
-      {
-        dataField: 'association',
-        header: 'Association',
-        display: true,
-        tooltipText: 'sort',
-        role: cellTypes.DISPLAY,
-      },
-      {
-        dataField: 'data_file_description',
-        header: 'Description',
-        display: true,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
       },

--- a/src/pages/dashTemplate/DashTemplateController.js
+++ b/src/pages/dashTemplate/DashTemplateController.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { connect } from 'react-redux';
+import { useLocation } from 'react-router-dom/cjs/react-router-dom';
 import { CircularProgress } from '@material-ui/core';
 import { getFilters } from '@bento-core/facet-filter';
 import DashTemplateView from './DashTemplateView';
@@ -11,6 +12,15 @@ const getDashData = (states) => {
     filterState,
     localFindUpload, localFindAutocomplete,
   } = states;
+
+  const tabIndexMap = {
+    'participants': 0,
+    'biospecimens': 1,
+    'files': 2,
+  };
+  const { search } = useLocation();
+  const tabName = search ? new URLSearchParams(search).get('selectedTab').toLowerCase() : 'participants';
+  const tabIndex = tabIndexMap[tabName];
 
   const client = useApolloClient();
   async function getData(activeFilters) {
@@ -41,11 +51,11 @@ const getDashData = (states) => {
     });
     return () => controller.abort();
   }, [filterState, localFindUpload, localFindAutocomplete]);
-  return { dashData, activeFilters };
+  return { dashData, activeFilters, tabIndex };
 };
 
 const DashTemplateController = ((props) => {
-  const { dashData, activeFilters } = getDashData(props);
+  const { dashData, activeFilters, tabIndex } = getDashData(props);
   if (!dashData) {
     return (<CircularProgress />);
   }
@@ -55,6 +65,7 @@ const DashTemplateController = ((props) => {
       {...props}
       dashData={dashData}
       activeFilters={activeFilters}
+      tabIndex={tabIndex}
     />
   );
 });

--- a/src/pages/dashTemplate/DashTemplateView.js
+++ b/src/pages/dashTemplate/DashTemplateView.js
@@ -11,6 +11,7 @@ const DashTemplate = ({
   classes,
   dashData,
   activeFilters,
+  tabIndex,
 }) => (
   <div className={classes.dashboardContainer}>
     <StatsView data={dashData} />
@@ -31,6 +32,7 @@ const DashTemplate = ({
             <TabsView
               dashboardStats={dashData}
               activeFilters={activeFilters}
+              tabIndex={tabIndex}
             />
           </div>
         </div>

--- a/src/pages/dashTemplate/tabs/TabsView.js
+++ b/src/pages/dashTemplate/tabs/TabsView.js
@@ -5,7 +5,7 @@ import { Tabs as BentoTabs }  from '@bento-core/tab';
 import { customTheme } from './DefaultTabTheme';
 
 const Tabs = (props) => {
-  const [currentTab, setCurrentTab] = useState(0);
+  const [currentTab, setCurrentTab] = useState(props.tabIndex || 0);
   const handleTabChange = (event, value) => {
     setCurrentTab(value);
   };

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -6,6 +6,7 @@ import {
   CircularProgress,
 } from '@material-ui/core';
 import { Link } from 'react-router-dom';
+import { clearAllFilters } from '@bento-core/facet-filter';
 
 import Snackbar from '../../components/Snackbar';
 import Stats from '../../components/Stats/AllStatsController';
@@ -18,6 +19,7 @@ import TabPanel from '../../components/Tab/TabPanel';
 import Styles from './studyDetailsStyle';
 import StudyThemeProvider from './studyDetailsThemeConfig';
 import Overview from './views/overview/overview';
+import store from '../../store';
 
 const StudyDetailView = ({ classes, data, isLoading=false, isError=false}) => {
   const studyData = data;
@@ -66,6 +68,10 @@ const StudyDetailView = ({ classes, data, isLoading=false, isError=false}) => {
     processedTabs = tab.items;
   }
 
+  const linkToDashboard = () => {
+    // TODO: Once local-find is enabled; dispatch(resetAllData()) from bento-core/local-find to RESET_LOCALFIND_ALL_DATA
+    store.dispatch(clearAllFilters());
+  };
 
   return (
     <StudyThemeProvider>
@@ -102,8 +108,7 @@ const StudyDetailView = ({ classes, data, isLoading=false, isError=false}) => {
               <Link
                 className={classes.headerButtonLink}
                 to={(location) => ({ ...location, pathname: '/explore' })}
-                // TO DO: Once Explore page is implemented
-                // onClick={() => navigatedToDashboard(studyData.clinical_study_designation, 'Cases')}
+                onClick={() => linkToDashboard()}
               >
                 <div className={classes.headerButtonLinkNumber}>
                   { studyData.studyByStudyShortName[0].participant_count || 0}

--- a/src/pages/studyDetail/views/BiospecimenProfile.js
+++ b/src/pages/studyDetail/views/BiospecimenProfile.js
@@ -36,9 +36,11 @@ const BiospecimenProfile = ({ classes, d }) => {
   const tabCount = biospecimenProfile.tabs.filter((tab) => (data[tab.value]
     && data[tab.value].length > 0));
 
-  // const linkToDashboard = () => {
-  //   navigatedToDashboard(studyCode, 'Samples');
-  // };
+  const biospecimenTabPathName = "/explore?selectedTab=biospecimens"
+
+  const linkToDashboard = () => {
+    // ToDo: Reset ActiveFilter to be empty
+  };
 
   const tabItem = (items) => (
     <Tabs
@@ -92,7 +94,7 @@ const BiospecimenProfile = ({ classes, d }) => {
               <span className={classes.headerButtonLinkSpan}>
                 <Link
                   className={classes.headerButtonLink}
-                  to={(location) => ({ ...location, pathname: '/explore' })}
+                  to={biospecimenTabPathName}
                   // onClick={() => linkToDashboard()}
                 >
                   <span className={classes.headerButtonLinkNumber}>

--- a/src/pages/studyDetail/views/BiospecimenProfile.js
+++ b/src/pages/studyDetail/views/BiospecimenProfile.js
@@ -7,6 +7,7 @@ import {
 } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { BarChart } from 'bento-components';
+import { clearAllFilters } from '@bento-core/facet-filter';
 import {
   biospecimenProfile,
   palette,
@@ -17,6 +18,7 @@ import {
 } from '../../../bento/studyDetailData';
 import TabPanel from '../../../components/Tab/TabPanel';
 // import { navigatedToDashboard } from '../../../utils/utils';
+import store from '../../../store';
 
 const tooltipContent = ({ argument, originalValue }) => (
   <div>
@@ -39,7 +41,8 @@ const BiospecimenProfile = ({ classes, d }) => {
   const biospecimenTabPathName = "/explore?selectedTab=biospecimens"
 
   const linkToDashboard = () => {
-    // ToDo: Reset ActiveFilter to be empty
+    // TODO: Once local-find is enabled; dispatch(resetAllData()) from bento-core/local-find to RESET_LOCALFIND_ALL_DATA
+    store.dispatch(clearAllFilters());
   };
 
   const tabItem = (items) => (
@@ -95,7 +98,7 @@ const BiospecimenProfile = ({ classes, d }) => {
                 <Link
                   className={classes.headerButtonLink}
                   to={biospecimenTabPathName}
-                  // onClick={() => linkToDashboard()}
+                  onClick={() => linkToDashboard()}
                 >
                   <span className={classes.headerButtonLinkNumber}>
                     {0 || data.sample_count}


### PR DESCRIPTION
CTDC-966 (Link Studies with Dash page):
- Set Biospecimens tab as default upon clicking on [#] Associated Samples instead of the Participants tab.
- Ensure clearing of any previously selected filters.

CTDC-1048:
- Update the "Access" column order under File tab