### PR TITLE
Reset Sunburst

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@bento-core/paginated-table": "1.0.1-ctdc.7",
     "@bento-core/table": "1.0.1-ctdc.5",
     "@bento-core/facet-filter": "1.0.1-ctdc.0",
+    "@bento-core/widgets": "1.0.0-ctdc.0",
     "@librpc/web": "^1.1.1",
     "@material-ui/core": "^4.12.4",
     "@material-ui/data-grid": "*",

--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -243,6 +243,7 @@ export const widgetConfig = [
     datatable_level1_colors: SUNBURST_COLORS_LEVEL_1,
     datatable_level2_field: 'arm', // Outer Ring
     datatable_level2_colors: SUNBURST_COLORS_LEVEL_2,
+    resetSunburstOnMouseOut: true, // Reset emphasis on mouse out
   },
   {
     type: 'sunburst',
@@ -253,6 +254,7 @@ export const widgetConfig = [
     datatable_level1_colors: SUNBURST_COLORS_LEVEL_1,
     datatable_level2_field: 'arm', // Outer Ring
     datatable_level2_colors: SUNBURST_COLORS_LEVEL_2,
+    resetSunburstOnMouseOut: true, // Reset emphasis on mouse out
   },
   {
     type: 'sunburst',
@@ -263,6 +265,7 @@ export const widgetConfig = [
     datatable_level1_colors: SUNBURST_COLORS_LEVEL_1,
     datatable_level2_field: 'arm',
     datatable_level2_colors: SUNBURST_COLORS_LEVEL_2,
+    resetSunburstOnMouseOut: true, // Reset emphasis on mouse out
   },
   {
     type: 'donut',
@@ -279,6 +282,7 @@ export const widgetConfig = [
     datatable_level1_colors: SUNBURST_COLORS_LEVEL_1,
     datatable_level2_field: 'arm',
     datatable_level2_colors: SUNBURST_COLORS_LEVEL_2,
+    resetSunburstOnMouseOut: true, // Reset emphasis on mouse out
   },
   {
     type: 'donut',

--- a/src/pages/dashTemplate/widget/WidgetView.js
+++ b/src/pages/dashTemplate/widget/WidgetView.js
@@ -106,6 +106,7 @@ const WidgetView = ({
                   sliceTitle={widget.sliceTitle}
                   chartTitleLocation="bottom"
                   chartTitleAlignment="center"
+                  resetSunburstOnMouseOut={widget.resetSunburstOnMouseOut}
                 />
               </Grid>
             );


### PR DESCRIPTION
Add `resetSunburstOnMouseOut` props to reset all sunburst widgets when the mouse exits. 

Prerequisite PR: https://github.com/CBIIT/bento-frontend/pull/953

Related PR:
- CTDC-1392
- CTDC-1387