### PR TITLE
Improved error handling for file downloading

### DIFF
--- a/public/injectEnv.js
+++ b/public/injectEnv.js
@@ -8,7 +8,7 @@ window.injectedEnv = {
 
   REACT_APP_BACKEND_API: 'https://trialcommons-dev.cancer.gov/v1/graphql/',
   REACT_APP_BACKEND_PUBLIC_API: 'https://4250bc0d-7018-4a95-bffb-d4dceb96fb4d.mock.pstmn.io/v1/graphql',
-  REACT_APP_FILE_SERVICE_API: 'http://localhost:3000/api/files/',
+  REACT_APP_FILE_SERVICE_API: 'https://trialcommons-dev.cancer.gov/api/files/',
   REACT_APP_AUTH_SERVICE_API: 'http://localhost:3000/api/auth/',
   REACT_APP_USER_SERVICE_API: 'http://localhost:3000/api/users/',
 

--- a/src/components/DocumentDownload/DocumentDownloadView.js
+++ b/src/components/DocumentDownload/DocumentDownloadView.js
@@ -28,6 +28,9 @@ const fetchFileToDownload = (fileURL = '', signOut, setShowModal, fileName, file
         signOut();
         setShowModal(true);
         return '';
+      } else if (response.status !== 200) {
+        console.error(`Failed to fetch the file. Server responded with: ${response.status} ${response.statusText}`);
+        return '';
       }
       return response.text();
     }).then((filePath) => {


### PR DESCRIPTION
Enhanced `fetchFileToDownload` to improve error handling by implementing specific error messages for non-200 response statuses and preventing file downloading when errors occur.

Related Ticket: CTDC-1138