### PR TITLE
CTDC-1578: Hide the "Sort by counts" for the Targeted Therapy facet

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@bento-core/global-search": "1.0.1-ctdc.0",
     "@bento-core/paginated-table": "1.0.1-ctdc.7",
     "@bento-core/table": "1.0.1-ctdc.5",
-    "@bento-core/facet-filter": "1.0.1-ctdc.2",
+    "@bento-core/facet-filter": "1.0.1-ctdc.3",
     "@bento-core/widgets": "1.0.1-ctdc.1",
     "@librpc/web": "^1.1.1",
     "@material-ui/core": "^4.12.4",

--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -140,6 +140,8 @@ export const facetsConfig = [
     sort_type: sortType.ALPHABET,
     show: true,
     defaultValue: DEFAULT_VALUE,
+
+    displayFacetCount: false,
   },
   {
     section: SAMPLES,


### PR DESCRIPTION
In this PR, The "Sort by counts" and counts for Targeted Therapy facet are hidden using `displayFacetCount`

[CTDC-1578](https://tracker.nci.nih.gov/browse/CTDC-1578)
Prerequisite PR: https://github.com/CBIIT/bento-frontend/pull/1039 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new environment variable for enhanced configuration.
  - Added new components for managing file-centric cart functionalities, including a dropdown for exporting files and a dialog for downloading file manifests.
  - Implemented a new `ReadMe` dialog component for displaying markdown content.

- **Improvements**
  - Updated API endpoint URLs for better data retrieval.
  - Enhanced styling and layout for various components, including the cart view and header.
  - Improved error handling and visual presentation in several components.

- **Bug Fixes**
  - Resolved issues related to outdated facets and improved data handling in the dashboard.

- **Refactor**
  - Restructured the dashboard data fetching logic for better performance and state management.
  - Refactored the pagination and sorting logic for the file-centric cart.

- **Chores**
  - Updated package dependencies to ensure compatibility and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->