### PR TITLE
CTDC-1618: Remove "Gender" Property from Explore Dashboard Table and File Manifest

### DIFF
--- a/public/injectEnv.js
+++ b/public/injectEnv.js
@@ -5,10 +5,10 @@ window.injectedEnv = {
   REACT_APP_APPLICATION_VERSION: 'YYYY_MM_DD/HH:MM',
 
   // Services API End Points:
-  REACT_APP_BACKEND_API: 'https://trialcommons-dev.cancer.gov/v1/graphql/',
+  REACT_APP_BACKEND_API: 'https://clinical.datacommons.cancer.gov/v1/graphql/',
   REACT_APP_BACKEND_PUBLIC_API: 'https://4250bc0d-7018-4a95-bffb-d4dceb96fb4d.mock.pstmn.io/v1/graphql',
-  REACT_APP_FILE_SERVICE_API: 'https://trialcommons-dev.cancer.gov/api/files/',
-  REACT_APP_AUTH_SERVICE_API: 'https://trialcommons-dev.cancer.gov/api/auth/',
+  REACT_APP_FILE_SERVICE_API: 'https://clinical.datacommons.cancer.gov/api/files/',
+  REACT_APP_AUTH_SERVICE_API: 'https://clinical.datacommons.cancer.gov/api/auth/',
   REACT_APP_USER_SERVICE_API: 'http://localhost:3000/api/users/',
   REACT_APP_LOGIN_URL: 'https://nci-crdc-staging.datacommons.io/user/oauth2/authorize?client_id=9ZpYjAWqntLON2Z4Jdvstwe9yCwPA3aFFpQOaZo4&response_type=code&redirect_uri=http://localhost:3000/login&scope=openid%20user',
 

--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -83,18 +83,6 @@ export const facetsConfig = [
   },
   {
     section: CASES,
-    label: 'Gender',
-    apiPath: 'participantCountByReportedGender',
-    apiForFiltering: 'filterParticipantCountByReportedGender',
-    datafield: 'reported_gender',
-    field: GROUP,
-    type: InputTypes.CHECKBOX,
-    sort_type: sortType.CUSTOM_NUMBER,
-    show: false,
-    defaultValue: DEFAULT_VALUE,
-  },
-  {
-    section: CASES,
     label: 'Race',
     apiPath: 'participantCountByRace',
     apiForFiltering: 'filterParticipantCountByRace',
@@ -255,19 +243,6 @@ export const widgetConfig = [
     sliceTitle: "Participants",
     dataName: 'participantCountBySex',
   },
-  /* Covert "Sex and Gender" sunburst to Sex donut above, preserving this for future implementation.
-    {
-      type: 'sunburst',
-      title: 'Sex and Gender',
-      sliceTitle: "Participants",
-      dataName: 'sexesAndGenders',
-      datatable_level1_field: 'program', // Inner Ring
-      datatable_level1_colors: SUNBURST_COLORS_LEVEL_1,
-      datatable_level2_field: 'arm', // Outer Ring
-      datatable_level2_colors: SUNBURST_COLORS_LEVEL_2,
-      resetSunburstOnMouseOut: true, // Reset emphasis on mouse out
-    },
-  */
   {
     type: 'sunburst',
     title: 'Race and Ethnicity',

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -91,7 +91,7 @@ query search(
   $stage_of_disease: [String],
   $tumor_grade: [String], 
   $sex: [String], 
-  $reported_gender: [String], 
+  # $reported_gender: [String], 
   $race: [String], $ethnicity: [String],
   $carcinogen_exposure: [String], 
   $targeted_therapy: [String],
@@ -106,7 +106,7 @@ query search(
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
     sex: $sex
-    reported_gender: $reported_gender
+    # reported_gender: $reported_gender
     race: $race
     ethnicity: $ethnicity
     carcinogen_exposure: $carcinogen_exposure
@@ -340,7 +340,7 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String],
     $sex: [String],
-    $reported_gender: [String],
+    # $reported_gender: [String],
     $race: [String],
     $ethnicity: [String],
     $carcinogen_exposure: [String],
@@ -361,7 +361,7 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      reported_gender: $reported_gender
+      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -382,7 +382,7 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
       tumor_grade,
       age_at_enrollment,
       sex,
-      reported_gender,
+      # reported_gender,
       race,
       ethnicity,
       carcinogen_exposure,
@@ -400,7 +400,7 @@ export const GET_BIOSPECIMENS_OVERVIEW_QUERY = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String],
     $sex: [String],
-    $reported_gender: [String],
+    # $reported_gender: [String],
     $race: [String],
     $ethnicity: [String],
     $carcinogen_exposure: [String],
@@ -421,7 +421,7 @@ export const GET_BIOSPECIMENS_OVERVIEW_QUERY = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      reported_gender: $reported_gender
+      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -458,7 +458,7 @@ export const GET_FILES_OVERVIEW_QUERY = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String],
     $sex: [String],
-    $reported_gender: [String],
+    # $reported_gender: [String],
     $race: [String],
     $ethnicity: [String],
     $carcinogen_exposure: [String],
@@ -479,7 +479,7 @@ export const GET_FILES_OVERVIEW_QUERY = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      reported_gender: $reported_gender
+      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -1314,7 +1314,7 @@ query participant_data_files(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  $reported_gender: [String],
+  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1335,7 +1335,7 @@ query participant_data_files(
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      reported_gender: $reported_gender
+      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -1364,7 +1364,7 @@ query biospecimenAddAllToCart(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  $reported_gender: [String],
+  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1389,7 +1389,7 @@ query biospecimenAddAllToCart(
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
     sex: $sex
-    reported_gender: $reported_gender
+    # reported_gender: $reported_gender
     race: $race
     ethnicity: $ethnicity
     carcinogen_exposure: $carcinogen_exposure
@@ -1422,7 +1422,7 @@ query fileAddSelectedToCart(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  $reported_gender: [String],
+  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1444,7 +1444,7 @@ query fileAddSelectedToCart(
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
     sex: $sex
-    reported_gender: $reported_gender
+    # reported_gender: $reported_gender
     race: $race
     ethnicity: $ethnicity
     carcinogen_exposure: $carcinogen_exposure
@@ -1472,7 +1472,7 @@ query participant_data_files(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  $reported_gender: [String],
+  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1493,7 +1493,7 @@ query participant_data_files(
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      reported_gender: $reported_gender
+      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -1521,7 +1521,7 @@ export const GET_ALL_FILEIDS_FROM_BIOSPECIMENS_TAB_FOR_ADD_ALL_CART = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String],
     $sex: [String],
-    $reported_gender: [String],
+    # $reported_gender: [String],
     $race: [String],
     $ethnicity: [String],
     $carcinogen_exposure: [String],
@@ -1546,7 +1546,7 @@ export const GET_ALL_FILEIDS_FROM_BIOSPECIMENS_TAB_FOR_ADD_ALL_CART = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      reported_gender: $reported_gender
+      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -1576,7 +1576,7 @@ query fileAddAllToCart(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  $reported_gender: [String],
+  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1597,7 +1597,7 @@ query fileAddAllToCart(
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
     sex: $sex
-    reported_gender: $reported_gender
+    # reported_gender: $reported_gender
     race: $race
     ethnicity: $ethnicity
     carcinogen_exposure: $carcinogen_exposure
@@ -1724,7 +1724,7 @@ export const tabContainers = [
       {
         dataField: 'reported_gender',
         header: 'Gender',
-        display: true,
+        display: false,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
         headerType: headerTypes.CUSTOM_ELEM,

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -91,7 +91,6 @@ query search(
   $stage_of_disease: [String],
   $tumor_grade: [String], 
   $sex: [String], 
-  # $reported_gender: [String], 
   $race: [String], $ethnicity: [String],
   $carcinogen_exposure: [String], 
   $targeted_therapy: [String],
@@ -106,7 +105,6 @@ query search(
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
     sex: $sex
-    # reported_gender: $reported_gender
     race: $race
     ethnicity: $ethnicity
     carcinogen_exposure: $carcinogen_exposure
@@ -125,17 +123,6 @@ query search(
     numberOfFiles
     
     diagnosesAndStageOfDiseases {
-      program
-      caseSize
-      children {
-        arm
-        caseSize
-        size
-        __typename
-      }
-      __typename
-    }
-    sexesAndGenders {
       program
       caseSize
       children {
@@ -214,16 +201,6 @@ query search(
       __typename
     }
     filterParticipantCountBySex {
-      group
-      subjects
-      __typename
-    }
-    participantCountByReportedGender {
-      group
-      subjects
-      __typename
-    }
-    filterParticipantCountByReportedGender {
       group
       subjects
       __typename
@@ -340,7 +317,6 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String],
     $sex: [String],
-    # $reported_gender: [String],
     $race: [String],
     $ethnicity: [String],
     $carcinogen_exposure: [String],
@@ -361,7 +337,6 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -382,7 +357,6 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
       tumor_grade,
       age_at_enrollment,
       sex,
-      # reported_gender,
       race,
       ethnicity,
       carcinogen_exposure,
@@ -400,7 +374,6 @@ export const GET_BIOSPECIMENS_OVERVIEW_QUERY = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String],
     $sex: [String],
-    # $reported_gender: [String],
     $race: [String],
     $ethnicity: [String],
     $carcinogen_exposure: [String],
@@ -421,7 +394,6 @@ export const GET_BIOSPECIMENS_OVERVIEW_QUERY = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -458,7 +430,6 @@ export const GET_FILES_OVERVIEW_QUERY = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String],
     $sex: [String],
-    # $reported_gender: [String],
     $race: [String],
     $ethnicity: [String],
     $carcinogen_exposure: [String],
@@ -479,7 +450,6 @@ export const GET_FILES_OVERVIEW_QUERY = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -1314,7 +1284,6 @@ query participant_data_files(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1335,7 +1304,6 @@ query participant_data_files(
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -1364,7 +1332,6 @@ query biospecimenAddAllToCart(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1389,7 +1356,6 @@ query biospecimenAddAllToCart(
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
     sex: $sex
-    # reported_gender: $reported_gender
     race: $race
     ethnicity: $ethnicity
     carcinogen_exposure: $carcinogen_exposure
@@ -1422,7 +1388,6 @@ query fileAddSelectedToCart(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1444,7 +1409,6 @@ query fileAddSelectedToCart(
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
     sex: $sex
-    # reported_gender: $reported_gender
     race: $race
     ethnicity: $ethnicity
     carcinogen_exposure: $carcinogen_exposure
@@ -1472,7 +1436,6 @@ query participant_data_files(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1493,7 +1456,6 @@ query participant_data_files(
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -1521,7 +1483,6 @@ export const GET_ALL_FILEIDS_FROM_BIOSPECIMENS_TAB_FOR_ADD_ALL_CART = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String],
     $sex: [String],
-    # $reported_gender: [String],
     $race: [String],
     $ethnicity: [String],
     $carcinogen_exposure: [String],
@@ -1546,7 +1507,6 @@ export const GET_ALL_FILEIDS_FROM_BIOSPECIMENS_TAB_FOR_ADD_ALL_CART = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure
@@ -1576,7 +1536,6 @@ query fileAddAllToCart(
   $stage_of_disease: [String],
   $tumor_grade: [String],
   $sex: [String],
-  # $reported_gender: [String],
   $race: [String],
   $ethnicity: [String],
   $carcinogen_exposure: [String],
@@ -1597,7 +1556,6 @@ query fileAddAllToCart(
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
     sex: $sex
-    # reported_gender: $reported_gender
     race: $race
     ethnicity: $ethnicity
     carcinogen_exposure: $carcinogen_exposure
@@ -1720,14 +1678,6 @@ export const tabContainers = [
         display: true,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
-      },
-      {
-        dataField: 'reported_gender',
-        header: 'Gender',
-        display: false,
-        tooltipText: 'sort',
-        role: cellTypes.DISPLAY,
-        headerType: headerTypes.CUSTOM_ELEM,
       },
       {
         dataField: 'race',

--- a/src/bento/fileCentricCartWorkflowData.js
+++ b/src/bento/fileCentricCartWorkflowData.js
@@ -136,7 +136,6 @@ export const GET_MY_CART_DATA_QUERY = gql`
       tumor_grade
       age_at_enrollment
       sex
-      # reported_gender
       race
       data_file_checksum_value
       ethnicity
@@ -179,7 +178,6 @@ query fileOverview(
     tumor_grade
     age_at_enrollment
     sex
-    # reported_gender
     race
     data_file_checksum_value
     ethnicity
@@ -224,7 +222,6 @@ export const GET_MY_CART_DATA_QUERY_DESC = gql` query filesInList(
     tumor_grade
     age_at_enrollment
     sex
-    # reported_gender
     race
     data_file_checksum_value
     ethnicity

--- a/src/bento/fileCentricCartWorkflowData.js
+++ b/src/bento/fileCentricCartWorkflowData.js
@@ -98,8 +98,8 @@ export const myFilesPageData = {
 };
  
 export const manifestData = {
-  keysToInclude: ['data_file_name', 'data_file_uuid','data_file_uuid', 'data_file_checksum_value','subject_id', 'parent_specimen_id', 'ctep_disease_term','meddra_disease_code', 'primary_disease_site','histology', 'stage_of_disease','tumor_grade', 'age_at_enrollment', 'sex', 'reported_gender', 'race','ethnicity','carcinogen_exposure','targeted_therapy','parent_specimen_id','anatomical_collection_site','tissue_category','assessment_timepoint','User_Comment'],
-  header: ['name', 'drs_uri' ,'File ID', 'Md5sum','Participant ID', 'Biospecimen ID', 'Diagnosis','MedDRA Disease Code', 'Primary Site','Histology', 'Stage of Disease', 'Tumor Grade', 'Age', 'Sex', 'Gender', 'Race', 'Ethnicity', 'Carcinogen Exposure', 'Targeted Therapy', 'Parent Biospecimen ID', 'Anatomical Collection Site','Tissue Category','Collection Timepoint','User Comment'],
+  keysToInclude: ['data_file_name', 'data_file_uuid','data_file_uuid', 'data_file_checksum_value','subject_id', 'parent_specimen_id', 'ctep_disease_term','meddra_disease_code', 'primary_disease_site','histology', 'stage_of_disease','tumor_grade', 'age_at_enrollment', 'sex', 'race','ethnicity','carcinogen_exposure','targeted_therapy','parent_specimen_id','anatomical_collection_site','tissue_category','assessment_timepoint','User_Comment'],
+  header: ['name', 'drs_uri' ,'File ID', 'Md5sum','Participant ID', 'Biospecimen ID', 'Diagnosis','MedDRA Disease Code', 'Primary Site','Histology', 'Stage of Disease', 'Tumor Grade', 'Age', 'Sex', 'Race', 'Ethnicity', 'Carcinogen Exposure', 'Targeted Therapy', 'Parent Biospecimen ID', 'Anatomical Collection Site','Tissue Category','Collection Timepoint','User Comment'],
 };
 
 // --------------- GraphQL query - Retrieve selected cases info --------------
@@ -136,7 +136,7 @@ export const GET_MY_CART_DATA_QUERY = gql`
       tumor_grade
       age_at_enrollment
       sex
-      reported_gender
+      # reported_gender
       race
       data_file_checksum_value
       ethnicity
@@ -179,7 +179,7 @@ query fileOverview(
     tumor_grade
     age_at_enrollment
     sex
-    reported_gender
+    # reported_gender
     race
     data_file_checksum_value
     ethnicity
@@ -224,7 +224,7 @@ export const GET_MY_CART_DATA_QUERY_DESC = gql` query filesInList(
     tumor_grade
     age_at_enrollment
     sex
-    reported_gender
+    # reported_gender
     race
     data_file_checksum_value
     ethnicity

--- a/src/bento/globalStatsData.js
+++ b/src/bento/globalStatsData.js
@@ -168,7 +168,6 @@ export const GET_GLOBAL_STATS_DATA_QUERY = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String], 
     $sex: [String], 
-    # $reported_gender: [String], 
     $race: [String], $ethnicity: [String],
     $carcinogen_exposure: [String], 
     $targeted_therapy: [String],
@@ -183,7 +182,6 @@ export const GET_GLOBAL_STATS_DATA_QUERY = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure

--- a/src/bento/globalStatsData.js
+++ b/src/bento/globalStatsData.js
@@ -168,7 +168,7 @@ export const GET_GLOBAL_STATS_DATA_QUERY = gql`
     $stage_of_disease: [String],
     $tumor_grade: [String], 
     $sex: [String], 
-    $reported_gender: [String], 
+    # $reported_gender: [String], 
     $race: [String], $ethnicity: [String],
     $carcinogen_exposure: [String], 
     $targeted_therapy: [String],
@@ -183,7 +183,7 @@ export const GET_GLOBAL_STATS_DATA_QUERY = gql`
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
       sex: $sex
-      reported_gender: $reported_gender
+      # reported_gender: $reported_gender
       race: $race
       ethnicity: $ethnicity
       carcinogen_exposure: $carcinogen_exposure

--- a/src/pages/dashTemplate/tabs/tableConfig/Column.js
+++ b/src/pages/dashTemplate/tabs/tableConfig/Column.js
@@ -41,16 +41,7 @@ export const CustomCellView = (props) => {
 
 export const CustomHeaderCellView = (props) => {
  
-  if (props.dataField === "reported_gender") {
-    return (
-      <>
-      <span style={{fontSize: '14px',width: '130px',textAlign: 'center'}}>
-       Gender <p style={{fontSize: '10px', lineHeight: '0px', margin: 0, textAlign: 'center',fontWeight: '700'}}>(if different than sex)</p>
-      </span>
-      </>
-    )
-  }
-  else if (props.dataField === "stage_of_disease") {
+  if (props.dataField === "stage_of_disease") {
     return (
       <>
       <span style={{fontSize: '14px',width: '130px',textAlign: 'center'}}>


### PR DESCRIPTION
Removed the Gender(`reported_gender`) property from the table displayed on the Explore Dashboard page and File Manifest

[CTDC-1618](https://tracker.nci.nih.gov/browse/CTDC-1618)