### PR TITLE
CTDC-1909: Added ZIP download based on File Type under Study Detail page

### DIFF
--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -126,15 +126,15 @@ export const seriesSetting = {
 
 export const tooltipConfig = {
   enable: true,
-  family: 'Open Sans',
+  family: "Open Sans",
   size: 13,
-  color: '#929292', // border Color
+  color: "#929292", // border Color
   width: 1,
   blur: 4,
   offsetX: 0,
   offsetY: 4,
   opacity: 0.25,
-  shadowColor: '#000000',
+  shadowColor: "#000000",
   arrowLength: 10,
   paddingTopBottom: 10,
   interactive: false,
@@ -306,6 +306,24 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
         count
       }
       specimen_count
+    }
+
+    studyZipFileQuery(study_id: $study_id) {
+      study_short_name
+      study_id
+      data_file_type
+      zip_files {
+        data_file_uuid
+        data_file_name
+        data_file_type
+        data_file_description
+        data_file_format
+        data_file_size
+        data_file_checksum_value
+        data_file_checksum_type
+        data_file_compression_status
+        data_file_location
+      }
     }
   }
 `;

--- a/src/pages/studyDetail/studyDetailController.js
+++ b/src/pages/studyDetail/studyDetailController.js
@@ -39,7 +39,9 @@ const StudyDetailController = ({ match }) => {
   }
 
   // Success state - render study view
-  return <StudyView data={data} study_id={study_id} />;
+  return (
+    <StudyView data={data} study_id={study_id} />
+  );
 };
 
 export default StudyDetailController;

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -28,6 +28,7 @@ const StudyDetailView = ({
   const studyData = data;
   const processedTabs = tab.items;
   const study_short_name = studyData?.studyByStudyShortName?.at(0)?.study_short_name;
+  const zipFileData = data?.studyZipFileQuery || [];
 
   const breadCrumbJson = [
     { name: "Studies", to: "/studies", isALink: true },
@@ -131,7 +132,7 @@ const StudyDetailView = ({
           case "overview":
             return (
               <TabPanel value={currentTab} index={index} maxWidth="1800px">
-                <Overview data={data} />
+                <Overview data={data} zipFileData={zipFileData} />
               </TabPanel>
             );
 

--- a/src/pages/studyDetail/views/overview/components/ZipDownloadView.js
+++ b/src/pages/studyDetail/views/overview/components/ZipDownloadView.js
@@ -23,6 +23,7 @@ const DocumentDownload = ({
   fileName,
   toolTipIcon,
   disabled = false, //  allow parent to fully disable the button (e.g., when no ZIP exists)
+  buttonText = 'ZIP FILE',
 }) => {
   const { signInWithAuthURL, signOut } = useAuth();
   const { isSignedIn } = useSelector((state) => state.login);
@@ -61,7 +62,7 @@ const DocumentDownload = ({
           classes={{ root: classes.disabledDownloadAllBtn }}
           disabled
         >
-          ZIP&nbsp;FILE
+          {buttonText}
           <img src={iconUnauthenticated || iconFileDownload} alt="download icon" className={classes.downloadIcon} />
         </Button>
         <ToolTip
@@ -91,7 +92,7 @@ const DocumentDownload = ({
           }
           variant="contained"
         >
-          ZIP&nbsp;FILE
+          {buttonText}
           <img src={iconFileDownload} alt="download icon" className={classes.downloadIcon} />
         </Button>
         <ToolTip
@@ -108,7 +109,7 @@ const DocumentDownload = ({
     buttonBlock = (
       <div className={classes.downloadAllBtnContainer}>
         <Button classes={{ root: classes.disabledDownloadAllBtn }} disabled>
-          ZIP&nbsp;FILE
+          {buttonText}
           <img src={iconUnauthenticated} alt="download icon" className={classes.downloadIcon} />
         </Button>
         <ToolTip
@@ -141,7 +142,7 @@ const DocumentDownload = ({
 
 const commonStyles = {
   buttonBase: {
-    width: '126px',
+    width: '210px',
     height: '46px',
     fontSize: '14px',
     lineHeight: '14px',
@@ -153,13 +154,13 @@ const commonStyles = {
     textAlign: 'center',
     boxShadow: 'none',
     filter: 'none',
+    textTransform: 'uppercase',
   },
 };
 
 const styles = () => ({
   downloadAllBtnContainer: {
     marginTop: '16px',
-    marginLeft: '10px',
   },
   downloadAllBtn: {
     ...commonStyles.buttonBase,
@@ -181,7 +182,7 @@ const styles = () => ({
     marginLeft: '10px',
   },
   customTooltip: {
-    maxWidth: '208px',
+    maxWidth: '500px',
     borderRadius: '5px',
     border: '.2px solid #C3C3C3',
     boxShadow: '0px 4px 10px 0px #00000040',

--- a/src/pages/studyDetail/views/overview/overview.js
+++ b/src/pages/studyDetail/views/overview/overview.js
@@ -81,6 +81,13 @@ const Overview = ({ classes, data }) => {
   const missingZipTooltip =
     'No ZIP file is available for download for this study.';
 
+  // Config for download buttons
+  const downloadButtons = [
+    { buttonText: 'Variant Call Files', tooltip: 'Download all variant call files (VCF) for this study' },
+    { buttonText: 'Variant Reports', tooltip: 'Download all variant reports (pdf) for this study' },
+    { buttonText: 'Radiology Images', tooltip: 'Download all radiology images (DICOM) for this study' },
+  ];
+
   return (
     <OverviewThemeProvider>
       <div className={classes.container}>
@@ -168,34 +175,25 @@ const Overview = ({ classes, data }) => {
                         represented within the application can be downloaded in the form of a .zip file by selecting
                         the ZIP FILE download option below.
 
-                        {hasZipFile ? (
-                          /* CASE 1 — ZIP file exists: enabled button */
+                        {downloadButtons.map((btn, index) => (
                           <ZipDownloadView
-                            disabled={false}
+                            key={index}
+                            disabled={!hasZipFile}
 
-                            fileFormat={zipFileData[documentDownloadProps.fileFormatColumn]}
-                            fileName={zipFileData[documentDownloadProps.fileNameColumn]}
-                            fileLocation={zipFileData[documentDownloadProps.fileLocationColumn]}
+                            fileFormat={hasZipFile ? zipFileData[documentDownloadProps.fileFormatColumn] : undefined}
+                            fileName={hasZipFile ? zipFileData[documentDownloadProps.fileNameColumn] : undefined}
+                            fileLocation={hasZipFile ? zipFileData[documentDownloadProps.fileLocationColumn] : undefined}
 
-                            toolTipTextFileDownload={documentDownloadProps.toolTipTextFileDownload}
+                            toolTipTextFileDownload={hasZipFile ? btn.tooltip : missingZipTooltip}
                             iconFileDownload={documentDownloadProps.iconFileDownload}
 
                             iconUnauthenticated={documentDownloadProps.iconUnauthenticated}
                             toolTipTextUnauthenticated={documentDownloadProps.toolTipTextUnauthenticated}
 
                             toolTipIcon={documentDownloadProps.toolTipIcon}
+                            buttonText={btn.buttonText}
                           />
-                        ) : (
-                          /* CASE 2 — No ZIP file: always disabled with custom tooltip */
-                          <ZipDownloadView
-                            disabled={true}
-
-                            toolTipTextFileDownload={missingZipTooltip}
-                            iconFileDownload={documentDownloadProps.iconFileDownload}
-
-                            toolTipIcon={documentDownloadProps.toolTipIcon}
-                          />
-                        )}
+                        ))}
                       </Grid>
                     </Grid>
                   </Grid>

--- a/src/pages/studyDetail/views/overview/overview.js
+++ b/src/pages/studyDetail/views/overview/overview.js
@@ -179,7 +179,7 @@ const Overview = ({ classes, data, zipFileData = [] }) => {
                         represented within the application can be downloaded in the form of a .zip file by selecting
                         the ZIP FILE download option below.
 
-                        {downloadButtons.map((btn, index) => {
+                        {downloadButtons.map((btn) => {
                           const zipFile = getZipFileForType(btn.dataFileType);
                           const hasZip = Boolean(zipFile);
 

--- a/src/pages/studyDetail/views/overview/overview.js
+++ b/src/pages/studyDetail/views/overview/overview.js
@@ -33,7 +33,7 @@ const documentDownloadProps = {
     toolTipIcon,
 }
 
-const Overview = ({ classes, data }) => {
+const Overview = ({ classes, data, zipFileData = [] }) => {
   // ----- Helpers -----
   const getAccessTypeString = (accessType) => {
     switch (accessType) {
@@ -73,20 +73,24 @@ const Overview = ({ classes, data }) => {
 
   const { study_name, study_description, study_type, dates_of_conduct, study_accession } = study;
 
-  // Study data files / ZIP file
-  const studyDataFiles = data?.StudyDataFileByStudyShortName?.[0]?.study_data_files || [];
-  const zipFileData = studyDataFiles.find(file => file?.data_file_format?.toLowerCase() === 'zip');
-
-  const hasZipFile = Boolean(zipFileData);
   const missingZipTooltip =
     'No ZIP file is available for download for this study.';
 
-  // Config for download buttons
+  // Config for download buttons mapped to backend data_file_type values
   const downloadButtons = [
-    { buttonText: 'Variant Call Files', tooltip: 'Download all variant call files (VCF) for this study' },
-    { buttonText: 'Variant Reports', tooltip: 'Download all variant reports (pdf) for this study' },
-    { buttonText: 'Radiology Images', tooltip: 'Download all radiology images (DICOM) for this study' },
+    { buttonText: 'Variant Call Files', dataFileType: 'Variant Call File', tooltip: 'Download all variant call files (VCF) for this study' },
+    { buttonText: 'Variant Reports', dataFileType: 'Variant Report', tooltip: 'Download all variant reports (PDF) for this study' },
+    { buttonText: 'Radiology Images', dataFileType: 'Radiology Imaging', tooltip: 'Download all radiology images (DICOM) for this study' },
   ];
+
+  /**
+   * Find the first zip file for a given data_file_type from the studyZipFileQuery response
+   */
+  const getZipFileForType = (dataFileType) => {
+    const entry = zipFileData.find((item) => item.data_file_type === dataFileType);
+    if (!entry || !entry.zip_files || entry.zip_files.length === 0) return null;
+    return entry.zip_files[0];
+  };
 
   return (
     <OverviewThemeProvider>
@@ -175,25 +179,30 @@ const Overview = ({ classes, data }) => {
                         represented within the application can be downloaded in the form of a .zip file by selecting
                         the ZIP FILE download option below.
 
-                        {downloadButtons.map((btn, index) => (
-                          <ZipDownloadView
-                            key={index}
-                            disabled={!hasZipFile}
+                        {downloadButtons.map((btn, index) => {
+                          const zipFile = getZipFileForType(btn.dataFileType);
+                          const hasZip = Boolean(zipFile);
 
-                            fileFormat={hasZipFile ? zipFileData[documentDownloadProps.fileFormatColumn] : undefined}
-                            fileName={hasZipFile ? zipFileData[documentDownloadProps.fileNameColumn] : undefined}
-                            fileLocation={hasZipFile ? zipFileData[documentDownloadProps.fileLocationColumn] : undefined}
+                          return (
+                            <ZipDownloadView
+                              key={btn.dataFileType}
+                              disabled={!hasZip}
 
-                            toolTipTextFileDownload={hasZipFile ? btn.tooltip : missingZipTooltip}
-                            iconFileDownload={documentDownloadProps.iconFileDownload}
+                              fileFormat={hasZip ? zipFile.data_file_format : undefined}
+                              fileName={hasZip ? zipFile.data_file_name : undefined}
+                              fileLocation={hasZip ? zipFile.data_file_uuid : undefined}
 
-                            iconUnauthenticated={documentDownloadProps.iconUnauthenticated}
-                            toolTipTextUnauthenticated={documentDownloadProps.toolTipTextUnauthenticated}
+                              toolTipTextFileDownload={hasZip ? btn.tooltip : missingZipTooltip}
+                              iconFileDownload={documentDownloadProps.iconFileDownload}
 
-                            toolTipIcon={documentDownloadProps.toolTipIcon}
-                            buttonText={btn.buttonText}
-                          />
-                        ))}
+                              iconUnauthenticated={documentDownloadProps.iconUnauthenticated}
+                              toolTipTextUnauthenticated={documentDownloadProps.toolTipTextUnauthenticated}
+
+                              toolTipIcon={documentDownloadProps.toolTipIcon}
+                              buttonText={btn.buttonText}
+                            />
+                          );
+                        })}
                       </Grid>
                     </Grid>
                   </Grid>

--- a/src/pages/studyDetail/views/overview/overview.js
+++ b/src/pages/studyDetail/views/overview/overview.js
@@ -79,7 +79,7 @@ const Overview = ({ classes, data, zipFileData = [] }) => {
   // Config for download buttons mapped to backend data_file_type values
   const downloadButtons = [
     { buttonText: 'Variant Call Files', dataFileType: 'Variant Call File', tooltip: 'Download all variant call files (VCF) for this study' },
-    { buttonText: 'Variant Reports', dataFileType: 'Variant Report', tooltip: 'Download all variant reports (PDF) for this study' },
+    { buttonText: 'Variant Reports', dataFileType: 'Variant Report', tooltip: 'Download all variant reports (pdf) for this study' },
     { buttonText: 'Radiology Images', dataFileType: 'Radiology Imaging', tooltip: 'Download all radiology images (DICOM) for this study' },
   ];
 


### PR DESCRIPTION
This pull request enhances the study detail page by adding support for multiple ZIP file downloads by file type, improving the download button UI, and updating the backend query to fetch ZIP file metadata for each type. The changes also include several UI and code style improvements.

**Feature: Multiple ZIP File Downloads by Type**
- Added a new GraphQL query (`studyZipFileQuery`) to fetch ZIP file metadata for each `data_file_type` associated with a study, enabling support for downloading different types of ZIP files (e.g., Variant Call Files, Variant Reports, Radiology Images).
- Updated the `Overview` component to render a download button for each supported file type, dynamically enabling or disabling buttons based on ZIP file availability and displaying appropriate tooltips. [[1]](diffhunk://#diff-af481cb5620951bdbc1b2e6cac32167651afeb6b558fa2c55382d72ef6597591L76-R94) [[2]](diffhunk://#diff-af481cb5620951bdbc1b2e6cac32167651afeb6b558fa2c55382d72ef6597591L171-R205)

**UI/UX Improvements**
- Increased the ZIP download button width and ensured button text is uppercase for better visibility and consistency. [[1]](diffhunk://#diff-4ac60f2ad37932cb0df290db7065f20d4f74772b93d539a7a6cc59fa9cb1b7fbL144-R145) [[2]](diffhunk://#diff-4ac60f2ad37932cb0df290db7065f20d4f74772b93d539a7a6cc59fa9cb1b7fbR157-L162)
- Expanded tooltip maximum width to accommodate longer messages.

**Component and Prop Updates**
- Modified `ZipDownloadView` to accept a customizable `buttonText` prop, allowing each download button to display a relevant label. [[1]](diffhunk://#diff-4ac60f2ad37932cb0df290db7065f20d4f74772b93d539a7a6cc59fa9cb1b7fbR26) [[2]](diffhunk://#diff-4ac60f2ad37932cb0df290db7065f20d4f74772b93d539a7a6cc59fa9cb1b7fbL64-R65) [[3]](diffhunk://#diff-4ac60f2ad37932cb0df290db7065f20d4f74772b93d539a7a6cc59fa9cb1b7fbL94-R95) [[4]](diffhunk://#diff-4ac60f2ad37932cb0df290db7065f20d4f74772b93d539a7a6cc59fa9cb1b7fbL111-R112)
- Adjusted `StudyDetailView` and `Overview` components to pass the new ZIP file data structure and props accordingly. [[1]](diffhunk://#diff-3bd968a16442472a3716461488df94a3f23c5e28a570f1b30ca5182057299850R31) [[2]](diffhunk://#diff-3bd968a16442472a3716461488df94a3f23c5e28a570f1b30ca5182057299850L134-R135) [[3]](diffhunk://#diff-af481cb5620951bdbc1b2e6cac32167651afeb6b558fa2c55382d72ef6597591L36-R36)

**Code Style and Minor Refactoring**
- Standardized string quotes in the tooltip configuration for consistency.
- Minor formatting improvements in component returns.

[CTDC-1909](https://tracker.nci.nih.gov/browse/CTDC-1909)