### PR TITLE
CTDC-2024: Fix Safari navbar item height mismatch for dropdown vs non-dropdown tabs

### DIFF
--- a/src/components/Header/components/NavbarDesktop.js
+++ b/src/components/Header/components/NavbarDesktop.js
@@ -43,7 +43,7 @@ const NavContainer = styled.div`
     position: relative;
     display: flex;
     justify-content: space-between;
-    align-items: end;
+    align-items: flex-end;
 `;
 
 const UlContainer = styled.ul`
@@ -56,6 +56,7 @@ const UlContainer = styled.ul`
 const LiSection = styled.li`
   display: inline-block;
   position: relative;
+  vertical-align: top;
   line-height: 50px;
   letter-spacing: 1px;
   text-align: center;


### PR DESCRIPTION
**Issue**  
In Safari, top-level navbar items with dropdown arrows rendered at a different vertical position/height than items without dropdowns. The same navbar looked correct in Chrome/Edge/Firefox.

**Root cause**  
Navbar items are rendered as `inline-block` list items. Safari is more sensitive to baseline alignment differences when inline-block children have different inline content and pseudo-elements (for example, dropdown arrow in `::after` vs direct link with no arrow). That baseline calculation made some items appear taller/lower.  
In addition, the container used `align-items: end`, which is less explicit for flexbox than `flex-end` and can be less predictable across browsers.

**Fix**  
Added `vertical-align: top;` to `LiSection` so all inline-block navbar items align to the same top edge instead of mixed baselines.  
Updated navbar container alignment from `align-items: end` to `align-items: flex-end` for clearer, more consistent flexbox behavior across browsers (including Safari).  
No behavior or routing logic changed, only styling alignment.

**Impact**  
Visual-only fix for Safari desktop navbar consistency.  
No API/state changes.  
No functional regression expected.

[CTDC-2024](https://tracker.nci.nih.gov/browse/CTDC-2024)