### PR TITLE
CTDC-1967: Update Query for Study Files tab under Study Detail page

### DIFF
--- a/src/bento/__tests__/studyDetailData.test.js
+++ b/src/bento/__tests__/studyDetailData.test.js
@@ -45,7 +45,7 @@ describe("studyFilesTableConfig", () => {
       true,
     );
     expect(studyFilesTableConfig.addFilesResponseKeys).toEqual([
-      "fileOverview",
+      "studyFileOverview",
       "data_file_uuid",
     ]);
   });

--- a/src/bento/__tests__/studyDetailData.test.js
+++ b/src/bento/__tests__/studyDetailData.test.js
@@ -109,14 +109,6 @@ describe("studyFilesTableConfig columns", () => {
     });
   });
 
-  it("includes association column", () => {
-    const associationCol = studyFilesTableConfig.columns.find(
-      (c) => c.dataField === "association",
-    );
-    expect(associationCol).toBeDefined();
-    expect(associationCol.header).toBe("Association");
-  });
-
   it("includes description column", () => {
     const descriptionCol = studyFilesTableConfig.columns.find(
       (c) => c.dataField === "data_file_description",

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -49,7 +49,7 @@ export const studyFilesTooltipContent = {
   alt: "tooltipIcon",
   arrow: false,
   classes: "customTooltip",
-  "Study_Files": STUDY_FILES_BUTTON_TOOLTIP,
+  Study_Files: STUDY_FILES_BUTTON_TOOLTIP,
 };
 
 // Study Detail: Study Files Tab table configuration
@@ -89,13 +89,6 @@ export const studyFilesTableConfig = {
       header: "File Type",
       display: true,
       role: cellTypes.DISPLAY,
-    },
-    {
-      dataField: "association",
-      header: "Association",
-      display: true,
-      role: cellTypes.DISPLAY,
-      tooltipText: "Sort",
     },
     {
       dataField: "data_file_description",
@@ -348,9 +341,20 @@ export const studyClinicalDataQuery = gql`
   }
 `;
 
-// --------------- GraphQL query configuration --------------
 export const GET_STUDY_DETAIL_DATA_QUERY = gql`
-  query studyByStudyShortNameQueries($study_id: [String]) {
+  query studyDetailPageQueries($study_id: [String]) {
+    # Study Files Tab: StudyFileTabByStudyShortName
+    StudyFileTabByStudyShortName(study_id: $study_id) {
+      data_file_name
+      data_file_type
+      data_file_format
+      data_file_size
+      data_file_description
+      data_file_uuid
+      study_accession
+      study_id
+    }
+
     # Clinical Data Tab: Node Counts
     clinicalDataNodeCounts: clinicalData(study_id: $study_id) {
       diagnosis: diagnosisNodeCount
@@ -402,27 +406,10 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
       ctep_disease_terms
     }
 
-    participantAndBiospecimenFilesByStudyId(study_id: $study_id) {
-      study_short_name
-      list_type
-      data_files {
-        data_file_uuid
-        data_file_name
-        data_file_type
-        data_file_description
-        data_file_format
-        data_file_size
-        data_file_checksum_value
-        data_file_checksum_type
-        data_file_compression_status
-        data_file_location
-        association
-      }
-    }
-
     StudyDataFileByStudyShortName(study_id: $study_id) {
       list_type
-      study_data_files {
+      # TODO: Remove the following fields if they are not needed 
+      study_data_files {      
         # association
         data_file_description
         data_file_size

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -85,7 +85,6 @@ export const GET_STUDY_FILES_QUERY = gql`
       data_file_format
       data_file_size
       data_file_uuid
-      association
     }
   }
 `;

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -64,6 +64,8 @@ export const studyFilesTableConfig = {
     noMatch: "No study-level files associated with this study.",
   },
   selectableRows: true,
+  defaultSortField: "data_file_name",
+  defaultSortDirection: "asc",
   extendedViewConfig: {
     pagination: true,
     manageViewColumns: { title: "View Columns" },
@@ -248,6 +250,43 @@ export const tooltipConfig = {
   interactive: false,
 };
 
+// Separate query for Study Files Tab with pagination support
+export const GET_STUDY_FILES_QUERY = gql`
+  query studyFileOverview(
+    $study_id: [String]
+    $study_short_name: [String]
+    $data_file_type: [String]
+    $data_file_format: [String]
+    $data_file_uuid: [String]
+    $study_accession: [String]
+    $first: Int
+    $offset: Int = 0
+    $order_by: String = "data_file_uuid"
+    $sort_direction: String = "asc"
+  ) {
+    studyFileOverview(
+      study_short_name: $study_short_name
+      study_id: $study_id
+      study_accession: $study_accession
+      data_file_type: $data_file_type
+      data_file_format: $data_file_format
+      data_file_uuid: $data_file_uuid
+      first: $first
+      offset: $offset
+      order_by: $order_by
+      sort_direction: $sort_direction
+    ) {
+      data_file_name
+      data_file_type
+      data_file_description
+      data_file_format
+      data_file_size
+      data_file_uuid
+      association
+    }
+  }
+`;
+
 export const studyClinicalDataQuery = gql`
   query clinicalDataTab($study_id: [String]) {
     clinicalData(study_id: $study_id) {
@@ -343,18 +382,6 @@ export const studyClinicalDataQuery = gql`
 
 export const GET_STUDY_DETAIL_DATA_QUERY = gql`
   query studyDetailPageQueries($study_id: [String]) {
-    # Study Files Tab: StudyFileTabByStudyShortName
-    StudyFileTabByStudyShortName(study_id: $study_id) {
-      data_file_name
-      data_file_type
-      data_file_format
-      data_file_size
-      data_file_description
-      data_file_uuid
-      study_accession
-      study_id
-    }
-
     # Clinical Data Tab: Node Counts
     clinicalDataNodeCounts: clinicalData(study_id: $study_id) {
       diagnosis: diagnosisNodeCount
@@ -408,8 +435,8 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
 
     StudyDataFileByStudyShortName(study_id: $study_id) {
       list_type
-      # TODO: Remove the following fields if they are not needed 
-      study_data_files {      
+      # TODO: Remove the following fields if they are not needed
+      study_data_files {
         # association
         data_file_description
         data_file_size

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -1,6 +1,5 @@
 import { cellTypes, dataFormatTypes } from "@bento-core/table";
 import gql from "graphql-tag";
-import { GET_FILE_IDS_FOR_SELECTED_FILES } from "./dashboardTabData";
 import downloadSuccess from "../assets/dash/downloadSuccess.svg";
 import downloadLock from "../assets/dash/downloadLock.svg";
 import previewLarge from "../assets/dash/previewLarge.svg";
@@ -52,14 +51,84 @@ export const studyFilesTooltipContent = {
   Study_Files: STUDY_FILES_BUTTON_TOOLTIP,
 };
 
+// --------------- GraphQL Queries for Study Files Tab ---------------
+
+// Separate query for Study Files Tab with pagination support
+export const GET_STUDY_FILES_QUERY = gql`
+  query studyFileOverview(
+    $study_id: [String]
+    $study_short_name: [String]
+    $data_file_type: [String]
+    $data_file_format: [String]
+    $data_file_uuid: [String]
+    $study_accession: [String]
+    $first: Int
+    $offset: Int = 0
+    $order_by: String = "data_file_uuid"
+    $sort_direction: String = "asc"
+  ) {
+    studyFileOverview(
+      study_short_name: $study_short_name
+      study_id: $study_id
+      study_accession: $study_accession
+      data_file_type: $data_file_type
+      data_file_format: $data_file_format
+      data_file_uuid: $data_file_uuid
+      first: $first
+      offset: $offset
+      order_by: $order_by
+      sort_direction: $sort_direction
+    ) {
+      data_file_name
+      data_file_type
+      data_file_description
+      data_file_format
+      data_file_size
+      data_file_uuid
+      association
+    }
+  }
+`;
+
+// Query for adding selected study files to cart
+export const GET_FILE_IDS_FOR_SELECTED_STUDY_FILES = gql`
+  query studyFileAddSelectedToCart(
+    $data_file_uuid: [String]
+    $study_id: [String]
+    $study_short_name: [String]
+    $data_file_type: [String]
+    $data_file_format: [String]
+    $study_accession: [String]
+    $first: Int
+    $offset: Int = 0
+    $order_by: String = "data_file_uuid"
+    $sort_direction: String = "asc"
+  ) {
+    studyFileOverview(
+      data_file_uuid: $data_file_uuid
+      study_id: $study_id
+      study_short_name: $study_short_name
+      study_accession: $study_accession
+      data_file_type: $data_file_type
+      data_file_format: $data_file_format
+      first: $first
+      offset: $offset
+      order_by: $order_by
+      sort_direction: $sort_direction
+    ) {
+      data_file_uuid
+    }
+  }
+`;
+
 // Study Detail: Study Files Tab table configuration
 export const studyFilesTableConfig = {
   name: "Study_Files",
   dataKey: "data_file_uuid",
   buttonText: "Add Selected Files",
   addFilesRequestVariableKey: "data_file_uuid",
-  addFilesResponseKeys: ["fileOverview", "data_file_uuid"],
-  addSelectedFilesQuery: GET_FILE_IDS_FOR_SELECTED_FILES,
+  addFilesResponseKeys: ["studyFileOverview", "data_file_uuid"],
+  addSelectedFilesQuery: GET_FILE_IDS_FOR_SELECTED_STUDY_FILES,
   tableMsg: {
     noMatch: "No study-level files associated with this study.",
   },
@@ -249,43 +318,6 @@ export const tooltipConfig = {
   paddingTopBottom: 10,
   interactive: false,
 };
-
-// Separate query for Study Files Tab with pagination support
-export const GET_STUDY_FILES_QUERY = gql`
-  query studyFileOverview(
-    $study_id: [String]
-    $study_short_name: [String]
-    $data_file_type: [String]
-    $data_file_format: [String]
-    $data_file_uuid: [String]
-    $study_accession: [String]
-    $first: Int
-    $offset: Int = 0
-    $order_by: String = "data_file_uuid"
-    $sort_direction: String = "asc"
-  ) {
-    studyFileOverview(
-      study_short_name: $study_short_name
-      study_id: $study_id
-      study_accession: $study_accession
-      data_file_type: $data_file_type
-      data_file_format: $data_file_format
-      data_file_uuid: $data_file_uuid
-      first: $first
-      offset: $offset
-      order_by: $order_by
-      sort_direction: $sort_direction
-    ) {
-      data_file_name
-      data_file_type
-      data_file_description
-      data_file_format
-      data_file_size
-      data_file_uuid
-      association
-    }
-  }
-`;
 
 export const studyClinicalDataQuery = gql`
   query clinicalDataTab($study_id: [String]) {

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -467,17 +467,6 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
 
     StudyDataFileByStudyShortName(study_id: $study_id) {
       list_type
-      # TODO: Remove the following fields if they are not needed
-      study_data_files {
-        # association
-        data_file_description
-        data_file_size
-        data_file_uuid
-        data_file_name
-        data_file_type
-        data_file_format
-        # association
-      }
     }
 
     StudySpecimenByStudyShortName(study_id: $study_id) {

--- a/src/components/Tab/TabPanel.js
+++ b/src/components/Tab/TabPanel.js
@@ -1,15 +1,7 @@
-import React from 'react';
+import React from "react";
 
-const TabPanel = ({
-  children,
-  value,
-  index,
-  maxWidth,
-}) => (
-  <div
-    role="tabpanel"
-    hidden={value !== index}
-  >
+const TabPanel = ({ children, value, index, maxWidth }) => (
+  <div role="tabpanel" hidden={value !== index}>
     <div style={{ maxWidth, margin: "0 auto" }}>{children}</div>
   </div>
 );

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -29,7 +29,6 @@ const StudyDetailView = ({
   const studyData = data;
   const processedTabs = tab.items;
   const study_short_name = studyData?.studyByStudyShortName?.at(0)?.study_short_name;
-  const studyFiles = data?.StudyFileTabByStudyShortName || [];
   const zipFileData = data?.studyZipFileQuery || [];
 
   const breadCrumbJson = [
@@ -156,7 +155,7 @@ const StudyDetailView = ({
             return (
               <TabPanel value={currentTab} index={index} maxWidth="1800px">
                 <StudyFilesView
-                  files={studyFiles}
+                  study_id={study_id}
                 />
               </TabPanel>
             );

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -133,7 +133,7 @@ const StudyDetailView = ({
         switch (processedTab.value) {
           case "overview":
             return (
-              <div key={index} hidden={currentTab !== index}>
+              <div key={processedTab.value} hidden={currentTab !== index}>
                 <TabPanel value={currentTab} index={index} maxWidth="1800px">
                   <Overview data={data} zipFileData={zipFileData} />
                 </TabPanel>
@@ -142,7 +142,7 @@ const StudyDetailView = ({
 
           case "clinical_data":
             return (
-              <div key={index} hidden={currentTab !== index}>
+              <div key={processedTab.value} hidden={currentTab !== index}>
                 <TabPanel value={currentTab} index={index} maxWidth="1800px">
                   <ClinicalDataController
                     dataCount={{
@@ -158,7 +158,7 @@ const StudyDetailView = ({
 
           case "study_files":
             return (
-              <div key={index} hidden={currentTab !== index}>
+              <div key={processedTab.value} hidden={currentTab !== index}>
                 <TabPanel value={currentTab} index={index} maxWidth="1800px">
                   <StudyFilesView study_id={study_id} />
                 </TabPanel>

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -29,7 +29,7 @@ const StudyDetailView = ({
   const studyData = data;
   const processedTabs = tab.items;
   const study_short_name = studyData?.studyByStudyShortName?.at(0)?.study_short_name;
-  const studyFiles = data?.participantAndBiospecimenFilesByStudyId?.[0]?.data_files || [];
+  const studyFiles = data?.StudyFileTabByStudyShortName || [];
   const zipFileData = data?.studyZipFileQuery || [];
 
   const breadCrumbJson = [

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -17,7 +17,7 @@ import Overview from "./views/overview/overview";
 import { onClearAllFilters } from "../dashTemplate/sideBar/BentoFilterUtils";
 import useDashboardTabs from "../dashTemplate/components/dashboard-tabs-store";
 import ClinicalDataController from "./views/clinical-data/ClinicalDataController";
-import StudyFilesView from './views/study-files/StudyFilesView';
+import StudyFilesView from "./views/study-files/StudyFilesView";
 import CustomBreadcrumb from "../../components/Breadcrumb/BreadcrumbView";
 const StudyDetailView = ({
   classes,
@@ -28,7 +28,8 @@ const StudyDetailView = ({
 }) => {
   const studyData = data;
   const processedTabs = tab.items;
-  const study_short_name = studyData?.studyByStudyShortName?.at(0)?.study_short_name;
+  const study_short_name =
+    studyData?.studyByStudyShortName?.at(0)?.study_short_name;
   const zipFileData = data?.studyZipFileQuery || [];
 
   const breadCrumbJson = [
@@ -132,32 +133,36 @@ const StudyDetailView = ({
         switch (processedTab.value) {
           case "overview":
             return (
-              <TabPanel value={currentTab} index={index} maxWidth="1800px">
-                <Overview data={data} zipFileData={zipFileData} />
-              </TabPanel>
+              <div key={index} hidden={currentTab !== index}>
+                <TabPanel value={currentTab} index={index} maxWidth="1800px">
+                  <Overview data={data} zipFileData={zipFileData} />
+                </TabPanel>
+              </div>
             );
 
           case "clinical_data":
             return (
-              <TabPanel value={currentTab} index={index} maxWidth="1800px">
-                <ClinicalDataController
-                  dataCount={{
-                    caseCount: clinicalDataNodeParticipantCounts,
-                    nodeCount: clinicalDataNodeCounts,
-                  }}
-                  study_id={study_id}
-                  study_short_name={study_short_name}
-                />
-              </TabPanel>
+              <div key={index} hidden={currentTab !== index}>
+                <TabPanel value={currentTab} index={index} maxWidth="1800px">
+                  <ClinicalDataController
+                    dataCount={{
+                      caseCount: clinicalDataNodeParticipantCounts,
+                      nodeCount: clinicalDataNodeCounts,
+                    }}
+                    study_id={study_id}
+                    study_short_name={study_short_name}
+                  />
+                </TabPanel>
+              </div>
             );
 
-          case 'study_files':
+          case "study_files":
             return (
-              <TabPanel value={currentTab} index={index} maxWidth="1800px">
-                <StudyFilesView
-                  study_id={study_id}
-                />
-              </TabPanel>
+              <div key={index} hidden={currentTab !== index}>
+                <TabPanel value={currentTab} index={index} maxWidth="1800px">
+                  <StudyFilesView study_id={study_id} />
+                </TabPanel>
+              </div>
             );
 
           default:

--- a/src/pages/studyDetail/views/study-files/StudyFilesView.js
+++ b/src/pages/studyDetail/views/study-files/StudyFilesView.js
@@ -46,6 +46,11 @@ const StudyFilesView = ({ classes, study_id }) => {
     0, // Will be updated by server response
   );
 
+  // Active filters for add to cart functionality
+  const activeFilters = {
+    study_id: [study_id],
+  };
+
   return (
     <div className={classes.container}>
       <div className={classes.tableWrapper}>
@@ -55,7 +60,7 @@ const StudyFilesView = ({ classes, study_id }) => {
             customTheme={wrapperTheme}
             classes={classes}
             section={studyFilesTableConfig.name}
-            activeFilters={{}}
+            activeFilters={activeFilters}
           >
             <Grid container>
               <Grid item xs={12}>

--- a/src/pages/studyDetail/views/study-files/StudyFilesView.js
+++ b/src/pages/studyDetail/views/study-files/StudyFilesView.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Grid, withStyles } from "@material-ui/core";
+import { useQuery } from "@apollo/client";
 import { useSelector } from "react-redux";
 import {
   TableContextProvider,
@@ -20,8 +21,6 @@ import styles from "./StudyFilesStyle";
 const initFilesTableState = (initialState) => ({
   ...initialState,
   title: studyFilesTableConfig.name,
-  query: GET_STUDY_FILES_QUERY,
-  paginationAPIField: "studyFileOverview",
   dataKey: studyFilesTableConfig.dataKey,
   tableMsg: studyFilesTableConfig.tableMsg,
   columns: configColumn(studyFilesTableConfig.columns),
@@ -39,11 +38,19 @@ const StudyFilesView = ({ classes, study_id }) => {
   // eslint-disable-next-line no-unused-vars
   const cartState = useSelector((state) => state.cartReducer);
 
+  // Fetch all study files once (client-side pagination)
+  const { loading, error, data } = useQuery(GET_STUDY_FILES_QUERY, {
+    variables: { study_id: [study_id], first: 10000 },
+    fetchPolicy: "cache-first", // Cache the results
+  });
+
+  const studyFiles = data?.studyFileOverview || [];
+
   const configuredWrapper = configWrapper(
     studyFilesTableConfig,
     wrapperConfig,
     "",
-    0, // Will be updated by server response
+    studyFiles.length,
   );
 
   // Active filters for add to cart functionality
@@ -68,11 +75,17 @@ const StudyFilesView = ({ classes, study_id }) => {
                   This study currently has the following Study Files directly
                   associated with it:
                 </span>
-                <TableView
-                  initState={initFilesTableState}
-                  themeConfig={{ ...themeConfig }}
-                  queryVariables={{ study_id: [study_id] }}
-                />
+                {loading && <div>Loading study files...</div>}
+                {error && <div>Error loading study files: {error.message}</div>}
+                {!loading && !error && (
+                  <TableView
+                    initState={initFilesTableState}
+                    themeConfig={{ ...themeConfig }}
+                    tblRows={studyFiles}
+                    totalRowCount={studyFiles.length}
+                    server={false}
+                  />
+                )}
               </Grid>
             </Grid>
           </Wrapper>

--- a/src/pages/studyDetail/views/study-files/StudyFilesView.js
+++ b/src/pages/studyDetail/views/study-files/StudyFilesView.js
@@ -11,40 +11,29 @@ import { configColumn } from "../../../dashTemplate/tabs/tableConfig/Column";
 import { themeConfig } from "./StudyFilesTheme";
 import { configWrapper, wrapperConfig } from "./wrapperConfig/Wrapper";
 import { customTheme as wrapperTheme } from "./wrapperConfig/Theme";
-import { studyFilesTableConfig } from "../../../../bento/studyDetailData";
+import {
+  studyFilesTableConfig,
+  GET_STUDY_FILES_QUERY,
+} from "../../../../bento/studyDetailData";
 import styles from "./StudyFilesStyle";
 
 const initFilesTableState = (initialState) => ({
   ...initialState,
   title: studyFilesTableConfig.name,
+  query: GET_STUDY_FILES_QUERY,
+  paginationAPIField: "studyFileOverview",
   dataKey: studyFilesTableConfig.dataKey,
   tableMsg: studyFilesTableConfig.tableMsg,
   columns: configColumn(studyFilesTableConfig.columns),
   selectedRows: [],
-  sortBy: "data_file_name",
-  sortOrder: "asc",
+  sortBy: studyFilesTableConfig.defaultSortField || "data_file_name",
+  sortOrder: studyFilesTableConfig.defaultSortDirection || "asc",
   rowsPerPage: 10,
   page: 0,
   extendedViewConfig: studyFilesTableConfig.extendedViewConfig,
 });
 
-export const formatAssociationValue = (value) => {
-  if (Array.isArray(value)) {
-    return value.filter(Boolean).join(", ");
-  }
-
-  if (typeof value !== "string" || !value.trim()) {
-    return value;
-  }
-
-  return value
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean)
-    .join(", ");
-};
-
-const StudyFilesView = ({ classes, files = [] }) => {
+const StudyFilesView = ({ classes, study_id }) => {
   // CRITICAL: Establish Redux context for child components (bento-core Wrapper)
   // Without this hook, Redux connect() in @bento-core components cannot access the store
   // eslint-disable-next-line no-unused-vars
@@ -54,13 +43,8 @@ const StudyFilesView = ({ classes, files = [] }) => {
     studyFilesTableConfig,
     wrapperConfig,
     "",
-    files.length,
+    0, // Will be updated by server response
   );
-
-  const normalizedFiles = files.map((file) => ({
-    ...file,
-    association: formatAssociationValue(file.association),
-  }));
 
   return (
     <div className={classes.container}>
@@ -82,10 +66,7 @@ const StudyFilesView = ({ classes, files = [] }) => {
                 <TableView
                   initState={initFilesTableState}
                   themeConfig={{ ...themeConfig }}
-                  queryVariables={{}}
-                  totalRowCount={normalizedFiles.length}
-                  server={false}
-                  tblRows={normalizedFiles}
+                  queryVariables={{ study_id: [study_id] }}
                 />
               </Grid>
             </Grid>

--- a/src/pages/studyDetail/views/study-files/StudyFilesView.js
+++ b/src/pages/studyDetail/views/study-files/StudyFilesView.js
@@ -40,7 +40,13 @@ const StudyFilesView = ({ classes, study_id }) => {
 
   // Fetch all study files once (client-side pagination)
   const { loading, error, data } = useQuery(GET_STUDY_FILES_QUERY, {
-    variables: { study_id: [study_id], first: 10000 },
+    skip: !study_id,
+    variables: {
+      study_id: [study_id],
+      first: 10000,
+      order_by: studyFilesTableConfig.defaultSortField,
+      sort_direction: studyFilesTableConfig.defaultSortDirection,
+    },
     fetchPolicy: "cache-first", // Cache the results
   });
 

--- a/src/pages/studyDetail/views/study-files/__tests__/StudyFilesView.test.js
+++ b/src/pages/studyDetail/views/study-files/__tests__/StudyFilesView.test.js
@@ -1,5 +1,4 @@
 import { studyFilesTableConfig } from "../../../../../bento/studyDetailData";
-import { formatAssociationValue } from "../StudyFilesView";
 
 /**
  * Mock graphqlClient to prevent Apollo Client initialization errors
@@ -62,32 +61,5 @@ describe("StudyFilesView Configuration", () => {
     expect(studyFilesTableConfig.tableMsg.noMatch).toBe(
       "No study-level files associated with this study.",
     );
-  });
-});
-
-describe("formatAssociationValue", () => {
-  it("joins array values with comma and space", () => {
-    const result = formatAssociationValue(["participant", "biospecimen"]);
-    expect(result).toBe("participant, biospecimen");
-  });
-
-  it("filters empty array values", () => {
-    const result = formatAssociationValue([
-      "participant",
-      "",
-      null,
-      "biospecimen",
-    ]);
-    expect(result).toBe("participant, biospecimen");
-  });
-
-  it("normalizes comma separated string spacing", () => {
-    const result = formatAssociationValue("participant,biospecimen");
-    expect(result).toBe("participant, biospecimen");
-  });
-
-  it("returns non-string, non-array values as is", () => {
-    expect(formatAssociationValue(null)).toBeNull();
-    expect(formatAssociationValue(undefined)).toBeUndefined();
   });
 });

--- a/src/pages/studyDetail/views/study-files/wrapperConfig/Wrapper.js
+++ b/src/pages/studyDetail/views/study-files/wrapperConfig/Wrapper.js
@@ -48,15 +48,26 @@ export const configWrapper = (tab, wrapperConfig, context, totalRowCount) => {
   const wrpConfig = wrapperConfig.map((container) => ({
     ...container,
     items: !container.paginatedTable
-      ? container.items.map((item) => ({
-          ...item,
-          title: getButtonTitle(tab, item),
-          addFileQuery: tab.addSelectedFilesQuery,
-          dataKey: tab.addFilesRequestVariableKey,
-          responseKeys: tab.addFilesResponseKeys,
-          alertMessage: item.alertMessage,
-          maxFileLimit: item.maxFileLimit,
-        }))
+      ? container.items
+          .filter((item) => {
+            // Hide ADD_SELECTED_FILES button when there are no files
+            if (
+              item.role === btnTypes.ADD_SELECTED_FILES &&
+              totalRowCount === 0
+            ) {
+              return false;
+            }
+            return true;
+          })
+          .map((item) => ({
+            ...item,
+            title: getButtonTitle(tab, item),
+            addFileQuery: tab.addSelectedFilesQuery,
+            dataKey: tab.addFilesRequestVariableKey,
+            responseKeys: tab.addFilesResponseKeys,
+            alertMessage: item.alertMessage,
+            maxFileLimit: item.maxFileLimit,
+          }))
       : [],
   }));
   return wrpConfig;


### PR DESCRIPTION
[CTDC-1967](https://tracker.nci.nih.gov/browse/CTDC-1967)

** **Prerequisite**: the BE PR must be merged and deployed first: https://github.com/CBIIT/crdc-ctdc-backend/pull/185

** **To test locally, you will need to run the updated Backend branch and reindex OpenSearch using the index changes included in the BE PR so the updated query is available to the UI.**

This pull request refactors the Study Files tab in the study detail view to use a dedicated paginated GraphQL query for fetching study-level files, removes the now-unused "association" column, and streamlines the code and configuration for maintainability. It also updates the UI to fetch and display study files dynamically, improves error/loading handling, and cleans up related tests and configuration.

**Key changes:**

**1. Study Files Data Fetching & Table Configuration**
- Introduced a new paginated GraphQL query (`GET_STUDY_FILES_QUERY`) specifically for the Study Files tab, replacing the previous static data approach. The table now fetches files dynamically based on `study_id`, supporting client-side pagination and improved performance. (`src/bento/studyDetailData.js`, `src/pages/studyDetail/views/study-files/StudyFilesView.js`) [[1]](diffhunk://#diff-c062fce380a34a18aa6262dcf0f2082b82b9b515ac43d2be0e21746da2effdc1L52-R137) [[2]](diffhunk://#diff-26d4e6b0682323f1094f79260c4836824aa73a6b44713a325230e5a2db7571e1L14-R18) [[3]](diffhunk://#diff-26d4e6b0682323f1094f79260c4836824aa73a6b44713a325230e5a2db7571e1L24-R59)
- Updated the table configuration to set default sort field/direction and response keys, and removed the "association" column from both configuration and tests. (`src/bento/studyDetailData.js`, `src/bento/__tests__/studyDetailData.test.js`) [[1]](diffhunk://#diff-c062fce380a34a18aa6262dcf0f2082b82b9b515ac43d2be0e21746da2effdc1L93-L99) [[2]](diffhunk://#diff-bc0b31e995e5f8c998a8015d716a01f7bc53729f1b66dd8548adab0d975b08d5L48-R48) [[3]](diffhunk://#diff-bc0b31e995e5f8c998a8015d716a01f7bc53729f1b66dd8548adab0d975b08d5L112-L119)

**2. UI/UX Improvements**
- Study Files tab now shows loading and error states while fetching data, and disables the "Add Selected Files" button if there are no files. (`src/pages/studyDetail/views/study-files/StudyFilesView.js`, `src/pages/studyDetail/views/study-files/wrapperConfig/Wrapper.js`) [[1]](diffhunk://#diff-26d4e6b0682323f1094f79260c4836824aa73a6b44713a325230e5a2db7571e1L74-R88) [[2]](diffhunk://#diff-2c6b1ab272214b9b2529037431209f326a012e54bc2fda2baf1b9d9f780d72c6L51-R62)
- Refactored the study detail view to pass `study_id` to the Study Files component instead of pre-fetched files, ensuring data consistency and separation of concerns. (`src/pages/studyDetail/studyDetailView.js`)

**3. Code Cleanup & Test Adjustments**
- Removed the unused `formatAssociationValue` function and its tests, as the "association" column is no longer present. (`src/pages/studyDetail/views/study-files/StudyFilesView.js`, `src/pages/studyDetail/views/study-files/__tests__/StudyFilesView.test.js`) [[1]](diffhunk://#diff-26d4e6b0682323f1094f79260c4836824aa73a6b44713a325230e5a2db7571e1L24-R59) [[2]](diffhunk://#diff-b2d89f0f3a3e7909575bbdda5b7c6c347cd03e44d0befd76f59972fc070f03bcL67-L93)
- Minor code style and import cleanups for consistency. (`src/components/Tab/TabPanel.js`, `src/pages/studyDetail/studyDetailView.js`) [[1]](diffhunk://#diff-a1767480e5f8a99e0811b1a34d8dacf43f2c8fa3e90545045146852adc5f25d9L1-R4) [[2]](diffhunk://#diff-3bd968a16442472a3716461488df94a3f23c5e28a570f1b30ca5182057299850L20-R20)

**4. GraphQL Query Adjustments**
- Updated and renamed the main study detail data query to clarify its purpose and removed legacy fields related to participant/biospecimen files that are no longer needed for the Study Files tab. (`src/bento/studyDetailData.js`) [[1]](diffhunk://#diff-c062fce380a34a18aa6262dcf0f2082b82b9b515ac43d2be0e21746da2effdc1L351-R416) [[2]](diffhunk://#diff-c062fce380a34a18aa6262dcf0f2082b82b9b515ac43d2be0e21746da2effdc1L405-R470)

These changes collectively modernize the Study Files tab, improve maintainability, and ensure it is powered by flexible, scalable GraphQL queries.

Previous PR: https://github.com/CBIIT/crdc-ctdc-ui/pull/311