### PR TITLE
CTDC-2105: breadcrumb refactoring

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -436,6 +436,8 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
       targeted_therapy_string
       best_response_to_targeted_therapy
 
+      study_short_name
+      study_id
       data_file_uuid
     }
   }

--- a/src/pages/participantDetail/components/HeaderPanel.js
+++ b/src/pages/participantDetail/components/HeaderPanel.js
@@ -12,15 +12,20 @@ const InfoRow = ({ classes, label, value }) => (
 const HeaderPanel = ({ classes, participant }) => {
   const breadCrumbJson = [
     {
-      name: 'Explore',
-      to: '/explore',
+      name: 'ALL STUDIES',
+      to: '/studies',
       isALink: true,
     },
     {
-      name: <><strong>Participant ID:</strong> {participant.participant_id}</>,
+      name: `${participant.study_short_name || ''} DETAIL`,
+      to: `/study/${participant.study_id}`,
+      isALink: !!participant.study_id,
+    },
+    {
+      name: participant.participant_id,
       to: '',
       isALink: false,
-    }
+    },
   ];
 
   return (

--- a/src/pages/participantDetail/components/HeaderPanel.js
+++ b/src/pages/participantDetail/components/HeaderPanel.js
@@ -17,8 +17,8 @@ const HeaderPanel = ({ classes, participant }) => {
       isALink: true,
     },
     {
-      name: `${participant.study_short_name || ''} DETAIL`,
-      to: `/study/${participant.study_id}`,
+      name: participant.study_short_name ? `${participant.study_short_name} DETAIL` : 'STUDY DETAIL',
+      to: participant.study_id ? `/study/${participant.study_id}` : '',
       isALink: !!participant.study_id,
     },
     {

--- a/src/pages/participantDetail/components/HeaderPanel.test.js
+++ b/src/pages/participantDetail/components/HeaderPanel.test.js
@@ -14,21 +14,23 @@ import HeaderPanel from './HeaderPanel';
 jest.mock('../../../components/Breadcrumb/BreadcrumbView', () => {
   const React = require('react');
   return function MockBreadcrumb(props) {
-    // Safely serialize data — props.data may contain JSX elements
-    let textContent = '';
-    try {
-      textContent = (props.data || []).map((item) => {
-        if (typeof item.name === 'string') return item.name;
-        // For JSX name values, extract the participant_id from the breadcrumb entry
-        return item.to || 'breadcrumb-item';
-      }).join(' > ');
-    } catch (e) {
-      textContent = 'breadcrumb';
-    }
+    const items = (props.data || []).map((item, i) => {
+      const name = typeof item.name === 'string' ? item.name : (item.to || 'breadcrumb-item');
+      return React.createElement(
+        'span',
+        {
+          key: i,
+          'data-crumb-index': i,
+          'data-to': item.to || '',
+          'data-is-link': String(!!item.isALink),
+        },
+        name,
+      );
+    });
     return React.createElement(
       'div',
       { 'data-testid': 'breadcrumb', 'data-separator': props.separator },
-      textContent,
+      ...items,
     );
   };
 });
@@ -104,16 +106,28 @@ describe('HeaderPanel', () => {
       // Act
       renderComponent(participant);
 
-      // Assert
+      // Assert – separator prop forwarded
       const breadcrumb = container.querySelector('[data-testid="breadcrumb"]');
       expect(breadcrumb).not.toBeNull();
       expect(breadcrumb.getAttribute('data-separator')).toBe('>');
-      // First crumb is now "ALL STUDIES" (not "Explore")
-      expect(breadcrumb.textContent).toContain('ALL STUDIES');
-      // Middle crumb shows the study short name
-      expect(breadcrumb.textContent).toContain('NCT001 DETAIL');
-      // Final crumb is the participant id
-      expect(breadcrumb.textContent).toContain('CTDC-001');
+
+      // Crumb 0 – "ALL STUDIES" links to /studies
+      const allStudiesCrumb = container.querySelector('[data-crumb-index="0"]');
+      expect(allStudiesCrumb.textContent).toBe('ALL STUDIES');
+      expect(allStudiesCrumb.getAttribute('data-to')).toBe('/studies');
+      expect(allStudiesCrumb.getAttribute('data-is-link')).toBe('true');
+
+      // Crumb 1 – study short name links to the study detail page
+      const studyCrumb = container.querySelector('[data-crumb-index="1"]');
+      expect(studyCrumb.textContent).toBe('NCT001 DETAIL');
+      expect(studyCrumb.getAttribute('data-to')).toBe('/study/ST-001');
+      expect(studyCrumb.getAttribute('data-is-link')).toBe('true');
+
+      // Crumb 2 – participant id is not a link
+      const participantCrumb = container.querySelector('[data-crumb-index="2"]');
+      expect(participantCrumb.textContent).toBe('CTDC-001');
+      expect(participantCrumb.getAttribute('data-to')).toBe('');
+      expect(participantCrumb.getAttribute('data-is-link')).toBe('false');
     });
 
     it('should fall back to "STUDY DETAIL" when study_short_name is missing', () => {
@@ -136,13 +150,16 @@ describe('HeaderPanel', () => {
       // Act
       renderComponent(participant);
 
-      // Assert – no leading space; clean fallback label
-      const breadcrumb = container.querySelector('[data-testid="breadcrumb"]');
-      expect(breadcrumb.textContent).not.toContain(' DETAIL');
-      expect(breadcrumb.textContent).toContain('STUDY DETAIL');
+      // Assert – fallback label, no null/undefined prefix, link still built from study_id
+      const studyCrumb = container.querySelector('[data-crumb-index="1"]');
+      expect(studyCrumb).not.toBeNull();
+      expect(studyCrumb.textContent).toBe('STUDY DETAIL');
+      expect(studyCrumb.textContent).not.toMatch(/^null |^undefined /);
+      expect(studyCrumb.getAttribute('data-to')).toBe('/study/ST-002');
+      expect(studyCrumb.getAttribute('data-is-link')).toBe('true');
     });
 
-    it('should not build a study link when study_id is missing', () => {
+    it('should set the study crumb as a non-link when study_id is missing', () => {
       // Arrange
       const participant = {
         participant_id: 'CTDC-003',
@@ -162,10 +179,12 @@ describe('HeaderPanel', () => {
       // Act
       renderComponent(participant);
 
-      // Assert – middle crumb is not a link (isALink false → to is '')
-      const breadcrumb = container.querySelector('[data-testid="breadcrumb"]');
-      expect(breadcrumb).not.toBeNull();
-      expect(breadcrumb.textContent).toContain('ALL STUDIES');
+      // Assert – middle crumb (index 1) shows fallback label, has no path, and isALink is false
+      const studyCrumb = container.querySelector('[data-crumb-index="1"]');
+      expect(studyCrumb).not.toBeNull();
+      expect(studyCrumb.textContent).toBe('STUDY DETAIL');
+      expect(studyCrumb.getAttribute('data-to')).toBe('');
+      expect(studyCrumb.getAttribute('data-is-link')).toBe('false');
     });
   });
 

--- a/src/pages/participantDetail/components/HeaderPanel.test.js
+++ b/src/pages/participantDetail/components/HeaderPanel.test.js
@@ -88,6 +88,8 @@ describe('HeaderPanel', () => {
       // Arrange
       const participant = {
         participant_id: 'CTDC-001',
+        study_short_name: 'NCT001',
+        study_id: 'ST-001',
         age_at_enrollment: 30,
         race: 'White',
         ethnicity: 'Not Hispanic',
@@ -106,8 +108,64 @@ describe('HeaderPanel', () => {
       const breadcrumb = container.querySelector('[data-testid="breadcrumb"]');
       expect(breadcrumb).not.toBeNull();
       expect(breadcrumb.getAttribute('data-separator')).toBe('>');
-      // The breadcrumb data includes "Explore" as the first entry
-      expect(breadcrumb.textContent).toContain('Explore');
+      // First crumb is now "ALL STUDIES" (not "Explore")
+      expect(breadcrumb.textContent).toContain('ALL STUDIES');
+      // Middle crumb shows the study short name
+      expect(breadcrumb.textContent).toContain('NCT001 DETAIL');
+      // Final crumb is the participant id
+      expect(breadcrumb.textContent).toContain('CTDC-001');
+    });
+
+    it('should fall back to "STUDY DETAIL" when study_short_name is missing', () => {
+      // Arrange
+      const participant = {
+        participant_id: 'CTDC-002',
+        study_short_name: null,
+        study_id: 'ST-002',
+        age_at_enrollment: 25,
+        race: 'Asian',
+        ethnicity: 'Hispanic',
+        sex: 'Female',
+        primary_diagnosis_disease_group: 'Sarcoma',
+        primary_disease_site: 'Bone',
+        stage_of_disease: 'Stage I',
+        targeted_therapy: null,
+        best_response_to_targeted_therapy: null,
+      };
+
+      // Act
+      renderComponent(participant);
+
+      // Assert – no leading space; clean fallback label
+      const breadcrumb = container.querySelector('[data-testid="breadcrumb"]');
+      expect(breadcrumb.textContent).not.toContain(' DETAIL');
+      expect(breadcrumb.textContent).toContain('STUDY DETAIL');
+    });
+
+    it('should not build a study link when study_id is missing', () => {
+      // Arrange
+      const participant = {
+        participant_id: 'CTDC-003',
+        study_short_name: null,
+        study_id: null,
+        age_at_enrollment: 40,
+        race: 'White',
+        ethnicity: 'Not Hispanic',
+        sex: 'Male',
+        primary_diagnosis_disease_group: 'CML',
+        primary_disease_site: 'Blood',
+        stage_of_disease: 'Stage II',
+        targeted_therapy: null,
+        best_response_to_targeted_therapy: null,
+      };
+
+      // Act
+      renderComponent(participant);
+
+      // Assert – middle crumb is not a link (isALink false → to is '')
+      const breadcrumb = container.querySelector('[data-testid="breadcrumb"]');
+      expect(breadcrumb).not.toBeNull();
+      expect(breadcrumb.textContent).toContain('ALL STUDIES');
     });
   });
 

--- a/src/pages/participantDetail/participantDetailController.js
+++ b/src/pages/participantDetail/participantDetailController.js
@@ -80,6 +80,8 @@ const ParticipantDetailController = ({ match }) => {
     targeted_therapy: formatPipeList(overviewRecord.targeted_therapy_string),
     best_response_to_targeted_therapy: formatPipeList(overviewRecord.best_response_to_targeted_therapy),
     primary_disease_site: biospecimenRecord.primary_disease_site,
+    study_short_name: overviewRecord.study_short_name,
+    study_id: overviewRecord.study_id,
   };
 
   const biospecimens = (biospecimensData?.biospecimenOverview || []).map((b) => ({


### PR DESCRIPTION
https://tracker.nci.nih.gov/browse/CTDC-2105

- Added `study_short_name` and `study_id` to the participant overview query so the participant detail page can link back to the related study.
- Updated the participant breadcrumb/header to show `ALL STUDIES > [study] DETAIL > participant ID` instead of just `Explore > Participant ID`.
- Passed the study fields through the participant detail controller to support that breadcrumb refactor.

