### PR TITLE
CTDC-2108: updated logic to hide button when there are no files

### DIFF
--- a/src/pages/participantDetail/components/FilesTable.js
+++ b/src/pages/participantDetail/components/FilesTable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   TableContextProvider,
   TableView,
@@ -6,7 +6,7 @@ import {
 } from '@bento-core/paginated-table';
 import { themeConfig, customTheme } from '../tableThemeConfig';
 import { filesColumns } from '../../../bento/participantDetailData';
-import { filesWrapperConfig } from '../wrapperConfig';
+import { getFilesWrapperConfig } from '../wrapperConfig';
 import { wrapperCustomTheme } from '../wrapperTheme';
 
 export const initFilesTableState = (initialState) => ({
@@ -30,29 +30,33 @@ export const initFilesTableState = (initialState) => ({
   },
 });
 
-const FilesTable = ({ classes, files = [] }) => (
-  <div className={classes.tableSection}>
-    <div className={classes.tableSectionTitle}>Associated Files</div>
-    <div className={classes.tableWrapper}>
-      <TableContextProvider>
-        <Wrapper
-          wrapConfig={filesWrapperConfig}
-          customTheme={wrapperCustomTheme}
-          classes={classes}
-          section="Files"
-        >
-          <TableView
-            initState={initFilesTableState}
-            themeConfig={{ ...themeConfig, customTheme }}
-            queryVariables={{}}
-            totalRowCount={files.length}
-            server={false}
-            tblRows={files}
-          />
-        </Wrapper>
-      </TableContextProvider>
+const FilesTable = ({ classes, files = [] }) => {
+  const wrapperConfig = useMemo(() => getFilesWrapperConfig(files.length), [files.length]);
+
+  return (
+    <div className={classes.tableSection}>
+      <div className={classes.tableSectionTitle}>Associated Files</div>
+      <div className={classes.tableWrapper}>
+        <TableContextProvider>
+          <Wrapper
+            wrapConfig={wrapperConfig}
+            customTheme={wrapperCustomTheme}
+            classes={classes}
+            section="Files"
+          >
+            <TableView
+              initState={initFilesTableState}
+              themeConfig={{ ...themeConfig, customTheme }}
+              queryVariables={{}}
+              totalRowCount={files.length}
+              server={false}
+              tblRows={files}
+            />
+          </Wrapper>
+        </TableContextProvider>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default FilesTable;

--- a/src/pages/participantDetail/components/FilesTable.test.js
+++ b/src/pages/participantDetail/components/FilesTable.test.js
@@ -1,4 +1,5 @@
 import { initFilesTableState } from './FilesTable';
+import { getFilesWrapperConfig } from '../wrapperConfig';
 
 /**
  * Purpose: Unit tests for initFilesTableState, the pure function that produces
@@ -101,5 +102,42 @@ describe('initFilesTableState', () => {
 
     // Assert
     expect(state.extendedViewConfig.download.downloadFileName).toBe('CTDC_Participant_Files');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getFilesWrapperConfig — button visibility
+// ─────────────────────────────────────────────────────────────────────────────
+describe('getFilesWrapperConfig', () => {
+  it('should always include the paginatedTable container first', () => {
+    const config = getFilesWrapperConfig(0);
+    expect(config[0]).toEqual({ container: 'paginatedTable', paginatedTable: true });
+  });
+
+  it('should not include a buttons container when fileCount is 0', () => {
+    const config = getFilesWrapperConfig(0);
+    expect(config).toHaveLength(1);
+    expect(config.find((c) => c.container === 'buttons')).toBeUndefined();
+  });
+
+  it('should include a buttons container when fileCount is 1', () => {
+    const config = getFilesWrapperConfig(1);
+    expect(config).toHaveLength(2);
+    const buttons = config.find((c) => c.container === 'buttons');
+    expect(buttons).toBeDefined();
+    expect(buttons.clsName).toBe('container_footer');
+  });
+
+  it('should include a buttons container when fileCount is greater than 1', () => {
+    const config = getFilesWrapperConfig(10);
+    expect(config).toHaveLength(2);
+    expect(config.find((c) => c.container === 'buttons')).toBeDefined();
+  });
+
+  it('should not include a buttons container for negative fileCount', () => {
+    // fileCount should never be negative in practice, but the function should not blow up
+    const config = getFilesWrapperConfig(-1);
+    expect(config).toHaveLength(1);
+    expect(config.find((c) => c.container === 'buttons')).toBeUndefined();
   });
 });

--- a/src/pages/participantDetail/wrapperConfig.js
+++ b/src/pages/participantDetail/wrapperConfig.js
@@ -121,15 +121,22 @@ if (showJBrowseButton) {
   });
 }
 
-export const filesWrapperConfig = [
-  {
-    container: 'paginatedTable',
-    paginatedTable: true,
-  },
-  {
-    container: 'buttons',
-    size: 'xl',
-    clsName: 'container_footer',
-    items: filesItems,
-  },
-];
+export const getFilesWrapperConfig = (fileCount) => {
+  const config = [
+    {
+      container: 'paginatedTable',
+      paginatedTable: true,
+    },
+  ];
+
+  if (fileCount > 0) {
+    config.push({
+      container: 'buttons',
+      size: 'xl',
+      clsName: 'container_footer',
+      items: filesItems,
+    });
+  }
+
+  return config;
+};


### PR DESCRIPTION
- Participant Files wrapper is now dynamic: wrapperConfig.js changed from static `filesWrapperConfig` to `getFilesWrapperConfig(fileCount)`.
- Footer buttons are now conditional: the buttons container is only added when `fileCount > 0`, so no file-action buttons show when there are zero files.
- Files table now computes wrapper config from data size via `useMemo`: FilesTable.js now calls `getFilesWrapperConfig(files.length)` instead of always using a fixed wrapper.