### PR TITLE
CTDC: 2107: updated logic for biospecimen button to check for associated files

### DIFF
--- a/src/components/AddToCartDialog/AddToCartDialogAlertView.js
+++ b/src/components/AddToCartDialog/AddToCartDialogAlertView.js
@@ -6,7 +6,7 @@ import DialogThemeProvider from './dialogThemeConfig';
 import { alertMessage } from '../../bento/fileCentricCartWorkflowData';
 
 function AddToCartDialogAlertView(props) {
-  const { open, classes, onClose } = props;
+  const { open, classes = {}, onClose } = props;
   const closeAlertModelTimer = 4000;
 
   const AlertDialog = (

--- a/src/components/AddToCartDialog/AddToCartDialogAlertView.js
+++ b/src/components/AddToCartDialog/AddToCartDialogAlertView.js
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Dialog, DialogContent, DialogContentText,
 } from '@material-ui/core';
 import DialogThemeProvider from './dialogThemeConfig';
-import { alertMessage } from '../../bento/fileCentricCartWorkflowData';
+import { alertMessage as defaultAlertMessage } from '../../bento/fileCentricCartWorkflowData';
 
 function AddToCartDialogAlertView(props) {
-  const { open, classes = {}, onClose } = props;
+  const { open, classes = {}, onClose, alertMessage = defaultAlertMessage } = props;
   const closeAlertModelTimer = 4000;
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const timer = setTimeout(() => { onClose(); }, closeAlertModelTimer);
+    return () => clearTimeout(timer);
+  }, [open, onClose]);
 
   const AlertDialog = (
     <DialogThemeProvider>
@@ -26,10 +32,6 @@ function AddToCartDialogAlertView(props) {
     </DialogThemeProvider>
   );
 
-  if (open === true) {
-    //  close the Dialog after 3 seconds.
-    setTimeout(() => { onClose(); }, closeAlertModelTimer);
-  }
   return AlertDialog;
 }
 

--- a/src/pages/participantDetail/components/AddBiospecimenFilesButton.js
+++ b/src/pages/participantDetail/components/AddBiospecimenFilesButton.js
@@ -1,0 +1,113 @@
+import React, { useContext, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useApolloClient } from '@apollo/client';
+import { Button, Snackbar } from '@material-ui/core';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import { onAddCartFiles } from '@bento-core/cart';
+import { TableContext, onRowSeclect } from '@bento-core/paginated-table';
+import ToolTip from '@bento-core/tool-tip';
+import {
+  GET_FILE_IDS_FOR_SELECTED_BIOSPECIMENS,
+} from '../../../bento/dashboardTabData';
+import {
+  alertMessage,
+  maximumNumberOfFilesAllowedInTheCart,
+} from '../../../bento/fileCentricCartWorkflowData';
+import {
+  BIOSPECIMEN_BUTTON_TOOLTIP,
+} from '../../../bento/participantDetailData';
+import AddToCartDialogAlertView from '../../../components/AddToCartDialog/AddToCartDialogAlertView';
+
+const HELP_ICON_URL = 'https://raw.githubusercontent.com/google/material-design-icons/master/src/action/help/materialicons/24px.svg';
+
+const AddBiospecimenFilesButton = ({ specimenIdsWithFiles }) => {
+  const { context } = useContext(TableContext);
+  const { selectedRows = [], dispatch: tableDispatch } = context;
+  const reduxDispatch = useDispatch();
+  const client = useApolloClient();
+  const cartCount = useSelector((state) => state.cartReducer?.count || 0);
+
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const [displayAlert, setDisplayAlert] = useState(false);
+
+  const hasFilesForSelection = selectedRows.some((id) => specimenIdsWithFiles.has(id));
+  const isDisabled = selectedRows.length === 0 || !hasFilesForSelection;
+
+  const handleAddFiles = async () => {
+    const variables = {
+      first: 10000,
+      specimen_record_id: selectedRows,
+    };
+
+    try {
+      const { data } = await client.query({
+        query: GET_FILE_IDS_FOR_SELECTED_BIOSPECIMENS,
+        variables,
+      });
+
+      const ids = (data.biospecimen_data_files || [])
+        .map((f) => f.data_file_uuid)
+        .filter(Boolean);
+
+      if (ids.length >= maximumNumberOfFilesAllowedInTheCart) {
+        setDisplayAlert(true);
+      } else {
+        reduxDispatch(onAddCartFiles(ids));
+        setOpenSnackbar(true);
+        tableDispatch(onRowSeclect([]));
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Error adding biospecimen files:', err);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        onClick={handleAddFiles}
+        className="add_selected_button add_selected_button_Biospecimens"
+        disableRipple
+        disabled={isDisabled}
+      >
+        ADD FILES FOR SELECTED BIOSPECIMENS
+      </Button>
+      <ToolTip title={BIOSPECIMEN_BUTTON_TOOLTIP} arrow={false}>
+        <img
+          className="add_selected_file_tooltip_icon"
+          src={HELP_ICON_URL}
+          alt="tooltipIcon"
+        />
+      </ToolTip>
+      <Snackbar
+        className="snackBar"
+        open={openSnackbar}
+        autoHideDuration={3000}
+        onClose={() => setOpenSnackbar(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        message={(
+          <div className="snackBarMessage">
+            <span className="snackBarMessageIcon">
+              <CheckCircleIcon />
+              {' '}
+            </span>
+            <span className="snackBarText">
+              {cartCount}
+              {' '}
+              File(s) successfully added to My Files.
+            </span>
+          </div>
+        )}
+      />
+      {displayAlert && (
+        <AddToCartDialogAlertView
+          alertMessage={alertMessage}
+          open={displayAlert}
+          onClose={() => setDisplayAlert(false)}
+        />
+      )}
+    </>
+  );
+};
+
+export default AddBiospecimenFilesButton;

--- a/src/pages/participantDetail/components/AddBiospecimenFilesButton.js
+++ b/src/pages/participantDetail/components/AddBiospecimenFilesButton.js
@@ -26,6 +26,7 @@ const AddBiospecimenFilesButton = ({ specimenIdsWithFiles }) => {
   const reduxDispatch = useDispatch();
   const client = useApolloClient();
   const cartCount = useSelector((state) => state.cartReducer?.count || 0);
+  const cartFiles = useSelector((state) => state.cartReducer?.filesId || []);
 
   const [openSnackbar, setOpenSnackbar] = useState(false);
   const [displayAlert, setDisplayAlert] = useState(false);
@@ -49,10 +50,14 @@ const AddBiospecimenFilesButton = ({ specimenIdsWithFiles }) => {
         .map((f) => f.data_file_uuid)
         .filter(Boolean);
 
-      if (ids.length >= maximumNumberOfFilesAllowedInTheCart) {
+      const existingCartIds = new Set(cartFiles);
+      const idsToAdd = ids.filter((id) => !existingCartIds.has(id));
+      const projectedTotal = existingCartIds.size + idsToAdd.length;
+
+      if (projectedTotal > maximumNumberOfFilesAllowedInTheCart) {
         setDisplayAlert(true);
       } else {
-        reduxDispatch(onAddCartFiles(ids));
+        reduxDispatch(onAddCartFiles(idsToAdd));
         setOpenSnackbar(true);
         tableDispatch(onRowSeclect([]));
       }

--- a/src/pages/participantDetail/components/AddBiospecimenFilesButton.js
+++ b/src/pages/participantDetail/components/AddBiospecimenFilesButton.js
@@ -20,6 +20,23 @@ import AddToCartDialogAlertView from '../../../components/AddToCartDialog/AddToC
 
 const HELP_ICON_URL = 'https://raw.githubusercontent.com/google/material-design-icons/master/src/action/help/materialicons/24px.svg';
 
+// --------------- Pure helpers (exported for unit testing) ---------------
+
+export const isAddButtonDisabled = (selectedRows, specimenIdsWithFiles) => {
+  if (selectedRows.length === 0) return true;
+  return !selectedRows.some((id) => specimenIdsWithFiles.has(id));
+};
+
+export const computeIdsToAdd = (fetchedIds, cartFiles) => {
+  const existingCartIds = new Set(cartFiles);
+  return [...new Set(fetchedIds)].filter((id) => !existingCartIds.has(id));
+};
+
+export const exceedsCartLimit = (idsToAdd, cartFiles, max) => {
+  const existingCartIds = new Set(cartFiles);
+  return existingCartIds.size + idsToAdd.length > max;
+};
+
 const AddBiospecimenFilesButton = ({ specimenIdsWithFiles }) => {
   const { context } = useContext(TableContext);
   const { selectedRows = [], dispatch: tableDispatch } = context;
@@ -30,11 +47,12 @@ const AddBiospecimenFilesButton = ({ specimenIdsWithFiles }) => {
 
   const [openSnackbar, setOpenSnackbar] = useState(false);
   const [displayAlert, setDisplayAlert] = useState(false);
+  const [loading, setLoading] = useState(false);
 
-  const hasFilesForSelection = selectedRows.some((id) => specimenIdsWithFiles.has(id));
-  const isDisabled = selectedRows.length === 0 || !hasFilesForSelection;
+  const isDisabled = loading || isAddButtonDisabled(selectedRows, specimenIdsWithFiles);
 
   const handleAddFiles = async () => {
+    setLoading(true);
     const variables = {
       first: 10000,
       specimen_record_id: selectedRows,
@@ -50,11 +68,11 @@ const AddBiospecimenFilesButton = ({ specimenIdsWithFiles }) => {
         .map((f) => f.data_file_uuid)
         .filter(Boolean);
 
-      const existingCartIds = new Set(cartFiles);
-      const idsToAdd = ids.filter((id) => !existingCartIds.has(id));
-      const projectedTotal = existingCartIds.size + idsToAdd.length;
+      const idsToAdd = computeIdsToAdd(ids, cartFiles);
 
-      if (projectedTotal > maximumNumberOfFilesAllowedInTheCart) {
+      if (idsToAdd.length === 0) {
+        // All files are already in the cart — nothing to add
+      } else if (exceedsCartLimit(idsToAdd, cartFiles, maximumNumberOfFilesAllowedInTheCart)) {
         setDisplayAlert(true);
       } else {
         reduxDispatch(onAddCartFiles(idsToAdd));
@@ -64,6 +82,8 @@ const AddBiospecimenFilesButton = ({ specimenIdsWithFiles }) => {
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('Error adding biospecimen files:', err);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -78,11 +98,15 @@ const AddBiospecimenFilesButton = ({ specimenIdsWithFiles }) => {
         ADD FILES FOR SELECTED BIOSPECIMENS
       </Button>
       <ToolTip title={BIOSPECIMEN_BUTTON_TOOLTIP} arrow={false}>
-        <img
-          className="add_selected_file_tooltip_icon"
-          src={HELP_ICON_URL}
-          alt="tooltipIcon"
-        />
+        <button
+          type="button"
+          aria-label={BIOSPECIMEN_BUTTON_TOOLTIP}
+          style={{
+            background: 'none', border: 'none', padding: 0, cursor: 'pointer', display: 'inline-flex',
+          }}
+        >
+          <img className="add_selected_file_tooltip_icon" src={HELP_ICON_URL} alt="" />
+        </button>
       </ToolTip>
       <Snackbar
         className="snackBar"

--- a/src/pages/participantDetail/components/AddBiospecimenFilesButton.test.js
+++ b/src/pages/participantDetail/components/AddBiospecimenFilesButton.test.js
@@ -227,7 +227,7 @@ describe('getBiospecimenWrapperConfig', () => {
 
   it('should include a buttons container when at least one file has a valid specimen_record_id', () => {
     const files = [{ specimen_record_id: 'sp-1', data_file_uuid: 'f-1' }];
-    const config = getBiospecimenWrapperConfig(files);
+    const config = getBiospecimenWrapperConfig(files, 1);
     expect(config).toHaveLength(2);
     const buttons = config.find((c) => c.container === 'buttons');
     expect(buttons).toBeDefined();
@@ -239,7 +239,15 @@ describe('getBiospecimenWrapperConfig', () => {
       { specimen_record_id: null, data_file_uuid: 'f-1' },
       { specimen_record_id: 'sp-2', data_file_uuid: 'f-2' },
     ];
-    const config = getBiospecimenWrapperConfig(files);
+    const config = getBiospecimenWrapperConfig(files, 2);
     expect(config).toHaveLength(2);
+  });
+
+  it('should not include a buttons container when biospecimenCount is 0 even if files have valid specimen_record_ids', () => {
+    // Arrange — files exist with specimen links but the biospecimen table is empty
+    const files = [{ specimen_record_id: 'sp-1', data_file_uuid: 'f-1' }];
+    const config = getBiospecimenWrapperConfig(files, 0);
+    expect(config).toHaveLength(1);
+    expect(config.find((c) => c.container === 'buttons')).toBeUndefined();
   });
 });

--- a/src/pages/participantDetail/components/AddBiospecimenFilesButton.test.js
+++ b/src/pages/participantDetail/components/AddBiospecimenFilesButton.test.js
@@ -1,0 +1,245 @@
+import {
+  isAddButtonDisabled,
+  computeIdsToAdd,
+  exceedsCartLimit,
+} from './AddBiospecimenFilesButton';
+import { getBiospecimenWrapperConfig } from '../wrapperConfig';
+
+/**
+ * Purpose: Unit tests for the pure helper functions extracted from
+ * AddBiospecimenFilesButton, covering the button disable predicate,
+ * cart de-duplication logic, and cart-limit overflow check.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isAddButtonDisabled
+// ─────────────────────────────────────────────────────────────────────────────
+describe('isAddButtonDisabled', () => {
+  it('should be disabled when no rows are selected', () => {
+    // Arrange
+    const specimenIdsWithFiles = new Set(['sp-1', 'sp-2']);
+
+    // Act & Assert
+    expect(isAddButtonDisabled([], specimenIdsWithFiles)).toBe(true);
+  });
+
+  it('should be disabled when selected rows have no associated files', () => {
+    // Arrange
+    const specimenIdsWithFiles = new Set(['sp-1', 'sp-2']);
+
+    // Act & Assert
+    expect(isAddButtonDisabled(['sp-3', 'sp-4'], specimenIdsWithFiles)).toBe(true);
+  });
+
+  it('should be enabled when at least one selected row has associated files', () => {
+    // Arrange
+    const specimenIdsWithFiles = new Set(['sp-1', 'sp-2']);
+
+    // Act & Assert
+    expect(isAddButtonDisabled(['sp-2', 'sp-3'], specimenIdsWithFiles)).toBe(false);
+  });
+
+  it('should be enabled when all selected rows have associated files', () => {
+    // Arrange
+    const specimenIdsWithFiles = new Set(['sp-1', 'sp-2']);
+
+    // Act & Assert
+    expect(isAddButtonDisabled(['sp-1', 'sp-2'], specimenIdsWithFiles)).toBe(false);
+  });
+
+  it('should be disabled when specimenIdsWithFiles is empty', () => {
+    // Arrange
+    const specimenIdsWithFiles = new Set();
+
+    // Act & Assert
+    expect(isAddButtonDisabled(['sp-1'], specimenIdsWithFiles)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeIdsToAdd
+// ─────────────────────────────────────────────────────────────────────────────
+describe('computeIdsToAdd', () => {
+  it('should return all fetched IDs when the cart is empty', () => {
+    // Arrange
+    const fetchedIds = ['file-1', 'file-2', 'file-3'];
+
+    // Act
+    const result = computeIdsToAdd(fetchedIds, []);
+
+    // Assert
+    expect(result).toEqual(['file-1', 'file-2', 'file-3']);
+  });
+
+  it('should return an empty array when all fetched IDs are already in the cart', () => {
+    // Arrange
+    const fetchedIds = ['file-1', 'file-2'];
+    const cartFiles = ['file-1', 'file-2'];
+
+    // Act
+    const result = computeIdsToAdd(fetchedIds, cartFiles);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it('should return only the IDs not already in the cart', () => {
+    // Arrange
+    const fetchedIds = ['file-1', 'file-2', 'file-3'];
+    const cartFiles = ['file-1', 'file-3'];
+
+    // Act
+    const result = computeIdsToAdd(fetchedIds, cartFiles);
+
+    // Assert
+    expect(result).toEqual(['file-2']);
+  });
+
+  it('should return an empty array when fetchedIds is empty', () => {
+    // Arrange
+    const cartFiles = ['file-1'];
+
+    // Act
+    const result = computeIdsToAdd([], cartFiles);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it('should deduplicate fetched IDs before filtering — same file linked to multiple biospecimens', () => {
+    // Arrange — 'file-1' appears twice (e.g. associated with two different biospecimens)
+    const fetchedIds = ['file-1', 'file-2', 'file-1'];
+
+    // Act
+    const result = computeIdsToAdd(fetchedIds, []);
+
+    // Assert — 'file-1' added only once
+    expect(result).toEqual(['file-1', 'file-2']);
+  });
+
+  it('should not add a duplicated ID that is already in the cart', () => {
+    // Arrange
+    const fetchedIds = ['file-1', 'file-1', 'file-2'];
+    const cartFiles = ['file-1'];
+
+    // Act
+    const result = computeIdsToAdd(fetchedIds, cartFiles);
+
+    // Assert — deduplicated and cart-filtered
+    expect(result).toEqual(['file-2']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// exceedsCartLimit
+// ─────────────────────────────────────────────────────────────────────────────
+describe('exceedsCartLimit', () => {
+  it('should return false when the projected total is under the limit', () => {
+    // Arrange
+    const idsToAdd = ['file-1', 'file-2'];
+    const cartFiles = ['file-3'];
+    const max = 10;
+
+    // Act & Assert
+    expect(exceedsCartLimit(idsToAdd, cartFiles, max)).toBe(false);
+  });
+
+  it('should return false when the projected total is exactly the limit', () => {
+    // Arrange
+    const idsToAdd = ['file-1', 'file-2'];
+    const cartFiles = ['file-3'];
+    const max = 3;
+
+    // Act & Assert
+    expect(exceedsCartLimit(idsToAdd, cartFiles, max)).toBe(false);
+  });
+
+  it('should return true when the projected total exceeds the limit', () => {
+    // Arrange
+    const idsToAdd = ['file-1', 'file-2'];
+    const cartFiles = ['file-3'];
+    const max = 2;
+
+    // Act & Assert
+    expect(exceedsCartLimit(idsToAdd, cartFiles, max)).toBe(true);
+  });
+
+  it('should return false when both idsToAdd and cart are empty', () => {
+    // Arrange & Act & Assert
+    expect(exceedsCartLimit([], [], 10)).toBe(false);
+  });
+
+  it('should return true when idsToAdd alone exceeds the limit', () => {
+    // Arrange
+    const idsToAdd = ['f1', 'f2', 'f3', 'f4'];
+
+    // Act & Assert
+    expect(exceedsCartLimit(idsToAdd, [], 3)).toBe(true);
+  });
+
+  it('should count duplicate cart entries only once', () => {
+    // Arrange — cart has the same ID stored twice (defensive)
+    const idsToAdd = ['file-new'];
+    const cartFiles = ['file-1', 'file-1', 'file-2'];
+    const max = 3;
+
+    // Act — existingCartIds.size = 2 (Set deduplicates), projected = 2 + 1 = 3
+    expect(exceedsCartLimit(idsToAdd, cartFiles, max)).toBe(false);
+  });
+
+  it('should return true when max is 0 and there are IDs to add', () => {
+    // Arrange & Act & Assert
+    expect(exceedsCartLimit(['file-1'], [], 0)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getBiospecimenWrapperConfig — button visibility
+// ─────────────────────────────────────────────────────────────────────────────
+describe('getBiospecimenWrapperConfig', () => {
+  it('should always include the paginatedTable container', () => {
+    const config = getBiospecimenWrapperConfig([]);
+    expect(config[0]).toEqual({ container: 'paginatedTable', paginatedTable: true });
+  });
+
+  it('should not include a buttons container when files is empty', () => {
+    const config = getBiospecimenWrapperConfig([]);
+    expect(config).toHaveLength(1);
+    expect(config.find((c) => c.container === 'buttons')).toBeUndefined();
+  });
+
+  it('should not include a buttons container when all files have null specimen_record_id', () => {
+    // Arrange — files exist but none have a valid specimen link
+    const files = [
+      { specimen_record_id: null, data_file_uuid: 'f-1' },
+      { specimen_record_id: null, data_file_uuid: 'f-2' },
+    ];
+    const config = getBiospecimenWrapperConfig(files);
+    expect(config).toHaveLength(1);
+    expect(config.find((c) => c.container === 'buttons')).toBeUndefined();
+  });
+
+  it('should not include a buttons container when all files have undefined specimen_record_id', () => {
+    const files = [{ data_file_uuid: 'f-1' }, { data_file_uuid: 'f-2' }];
+    const config = getBiospecimenWrapperConfig(files);
+    expect(config).toHaveLength(1);
+  });
+
+  it('should include a buttons container when at least one file has a valid specimen_record_id', () => {
+    const files = [{ specimen_record_id: 'sp-1', data_file_uuid: 'f-1' }];
+    const config = getBiospecimenWrapperConfig(files);
+    expect(config).toHaveLength(2);
+    const buttons = config.find((c) => c.container === 'buttons');
+    expect(buttons).toBeDefined();
+    expect(buttons.clsName).toBe('container_footer');
+  });
+
+  it('should include a buttons container when files has mixed valid and null specimen_record_id', () => {
+    const files = [
+      { specimen_record_id: null, data_file_uuid: 'f-1' },
+      { specimen_record_id: 'sp-2', data_file_uuid: 'f-2' },
+    ];
+    const config = getBiospecimenWrapperConfig(files);
+    expect(config).toHaveLength(2);
+  });
+});

--- a/src/pages/participantDetail/components/BiospecimensTable.js
+++ b/src/pages/participantDetail/components/BiospecimensTable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   TableContextProvider,
   TableView,
@@ -6,7 +6,7 @@ import {
 } from '@bento-core/paginated-table';
 import { themeConfig, customTheme } from '../tableThemeConfig';
 import { biospecimenColumns } from '../../../bento/participantDetailData';
-import { biospecimenWrapperConfig } from '../wrapperConfig';
+import { getBiospecimenWrapperConfig } from '../wrapperConfig';
 import { wrapperCustomTheme } from '../wrapperTheme';
 
 export const initBiospecimenTableState = (initialState) => ({
@@ -30,29 +30,33 @@ export const initBiospecimenTableState = (initialState) => ({
   },
 });
 
-const BiospecimensTable = ({ classes, biospecimens = [] }) => (
-  <div className={classes.tableSection}>
-    <div className={classes.tableSectionTitle}>Associated Biospecimens</div>
-    <div className={classes.tableWrapper}>
-      <TableContextProvider>
-        <Wrapper
-          wrapConfig={biospecimenWrapperConfig}
-          customTheme={wrapperCustomTheme}
-          classes={classes}
-          section="Biospecimens"
-        >
-          <TableView
-            initState={initBiospecimenTableState}
-            themeConfig={{ ...themeConfig, customTheme }}
-            queryVariables={{}}
-            totalRowCount={biospecimens.length}
-            server={false}
-            tblRows={biospecimens}
-          />
-        </Wrapper>
-      </TableContextProvider>
+const BiospecimensTable = ({ classes, biospecimens = [], files = [] }) => {
+  const wrapperConfig = useMemo(() => getBiospecimenWrapperConfig(files), [files]);
+
+  return (
+    <div className={classes.tableSection}>
+      <div className={classes.tableSectionTitle}>Associated Biospecimens</div>
+      <div className={classes.tableWrapper}>
+        <TableContextProvider>
+          <Wrapper
+            wrapConfig={wrapperConfig}
+            customTheme={wrapperCustomTheme}
+            classes={classes}
+            section="Biospecimens"
+          >
+            <TableView
+              initState={initBiospecimenTableState}
+              themeConfig={{ ...themeConfig, customTheme }}
+              queryVariables={{}}
+              totalRowCount={biospecimens.length}
+              server={false}
+              tblRows={biospecimens}
+            />
+          </Wrapper>
+        </TableContextProvider>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default BiospecimensTable;

--- a/src/pages/participantDetail/components/BiospecimensTable.js
+++ b/src/pages/participantDetail/components/BiospecimensTable.js
@@ -31,7 +31,10 @@ export const initBiospecimenTableState = (initialState) => ({
 });
 
 const BiospecimensTable = ({ classes, biospecimens = [], files = [] }) => {
-  const wrapperConfig = useMemo(() => getBiospecimenWrapperConfig(files), [files]);
+  const wrapperConfig = useMemo(
+    () => getBiospecimenWrapperConfig(files, biospecimens.length),
+    [files, biospecimens.length],
+  );
 
   return (
     <div className={classes.tableSection}>

--- a/src/pages/participantDetail/components/BiospecimensTable.js
+++ b/src/pages/participantDetail/components/BiospecimensTable.js
@@ -13,7 +13,7 @@ export const initBiospecimenTableState = (initialState) => ({
   ...initialState,
   title: 'Biospecimens',
   dataKey: 'specimen_record_id',
-  tableMsg: { noMatch: 'No biospecimens associated with this participant.' },
+  tableMsg: { noMatch: 'There are no biospecimens available for this participant.' },
   columns: biospecimenColumns,
   selectedRows: [],
   sortBy: 'specimen_record_id',

--- a/src/pages/participantDetail/components/BiospecimensTable.test.js
+++ b/src/pages/participantDetail/components/BiospecimensTable.test.js
@@ -26,7 +26,7 @@ describe('initBiospecimenTableState', () => {
     expect(state.page).toBe(0);
     expect(state.selectedRows).toEqual([]);
     expect(state.tableMsg).toEqual({
-      noMatch: 'No biospecimens associated with this participant.',
+      noMatch: 'There are no biospecimens available for this participant.',
     });
     expect(state.extendedViewConfig).toEqual({
       pagination: false,

--- a/src/pages/participantDetail/participantDetailView.js
+++ b/src/pages/participantDetail/participantDetailView.js
@@ -12,7 +12,7 @@ const ParticipantDetailView = ({ classes, participant, biospecimens, files }) =>
     <Stats />
     <div className={classes.container}>
       <HeaderPanel classes={classes} participant={participant} />
-      <BiospecimensTable classes={classes} biospecimens={biospecimens} />
+      <BiospecimensTable classes={classes} biospecimens={biospecimens} files={files} />
       <FilesTable classes={classes} files={files} />
     </div>
   </ParticipantThemeProvider>

--- a/src/pages/participantDetail/wrapperConfig.js
+++ b/src/pages/participantDetail/wrapperConfig.js
@@ -6,18 +6,17 @@ import {
   types,
 } from '@bento-core/paginated-table';
 import {
-  GET_FILE_IDS_FOR_SELECTED_BIOSPECIMENS,
   GET_FILE_IDS_FOR_SELECTED_FILES,
 } from '../../bento/dashboardTabData';
 import {
   alertMessage,
 } from '../../bento/fileCentricCartWorkflowData';
 import {
-  BIOSPECIMEN_BUTTON_TOOLTIP,
   FILES_BUTTON_TOOLTIP,
   showJBrowseButton,
 } from '../../bento/participantDetailData';
 import jbrowseIcon from '../../assets/participant/jbrowse_icon.png';
+import AddBiospecimenFilesButton from './components/AddBiospecimenFilesButton';
 
 // --------------- JBrowse custom element ---------------
 const JBrowseButton = () => (
@@ -48,13 +47,6 @@ const JBrowseButton = () => (
 // --------------- Tooltip configs ---------------
 const HELP_ICON_URL = 'https://raw.githubusercontent.com/google/material-design-icons/master/src/action/help/materialicons/24px.svg';
 
-const biospecimenTooltip = {
-  icon: HELP_ICON_URL,
-  alt: 'tooltipIcon',
-  arrow: false,
-  tooltipText: BIOSPECIMEN_BUTTON_TOOLTIP,
-};
-
 const filesTooltip = {
   icon: HELP_ICON_URL,
   alt: 'tooltipIcon',
@@ -63,40 +55,40 @@ const filesTooltip = {
 };
 
 // --------------- Biospecimens table wrapper config ---------------
-const biospecimenItems = [
-  {
-    title: 'ADD FILES FOR SELECTED BIOSPECIMENS',
-    clsName: 'add_selected_button',
-    type: types.BUTTON,
-    role: btnTypes.ADD_SELECTED_FILES,
-    btnType: btnTypes.ADD_SELECTED_FILES,
-    tooltipCofig: biospecimenTooltip,
-    addFileQuery: GET_FILE_IDS_FOR_SELECTED_BIOSPECIMENS,
-    dataKey: 'specimen_record_id',
-    responseKeys: ['biospecimen_data_files', 'data_file_uuid'],
-    alertMessage,
-  },
-];
+export const getBiospecimenWrapperConfig = (files = []) => {
+  const specimenIdsWithFiles = new Set(
+    files.map((f) => f.specimen_record_id).filter(Boolean),
+  );
 
-if (showJBrowseButton) {
-  biospecimenItems.push({
-    type: types.CUSTOM_ELEM,
-    customViewElem: JBrowseButton,
-  });
-}
+  const biospecimenItems = [
+    {
+      type: types.CUSTOM_ELEM,
+      customViewElem: () => (
+        <AddBiospecimenFilesButton specimenIdsWithFiles={specimenIdsWithFiles} />
+      ),
+    },
+  ];
 
-export const biospecimenWrapperConfig = [
-  {
-    container: 'paginatedTable',
-    paginatedTable: true,
-  },
-  {
-    container: 'buttons',
-    size: 'xl',
-    clsName: 'container_footer',
-    items: biospecimenItems,
-  },
-];
+  if (showJBrowseButton) {
+    biospecimenItems.push({
+      type: types.CUSTOM_ELEM,
+      customViewElem: JBrowseButton,
+    });
+  }
+
+  return [
+    {
+      container: 'paginatedTable',
+      paginatedTable: true,
+    },
+    {
+      container: 'buttons',
+      size: 'xl',
+      clsName: 'container_footer',
+      items: biospecimenItems,
+    },
+  ];
+};
 
 // --------------- Files table wrapper config ---------------
 const filesItems = [

--- a/src/pages/participantDetail/wrapperConfig.js
+++ b/src/pages/participantDetail/wrapperConfig.js
@@ -55,7 +55,7 @@ const filesTooltip = {
 };
 
 // --------------- Biospecimens table wrapper config ---------------
-export const getBiospecimenWrapperConfig = (files = []) => {
+export const getBiospecimenWrapperConfig = (files = [], biospecimenCount = 0) => {
   const specimenIdsWithFiles = new Set(
     files.map((f) => f.specimen_record_id).filter(Boolean),
   );
@@ -83,7 +83,7 @@ export const getBiospecimenWrapperConfig = (files = []) => {
     },
   ];
 
-  if (specimenIdsWithFiles.size > 0) {
+  if (biospecimenCount > 0 && specimenIdsWithFiles.size > 0) {
     config.push({
       container: 'buttons',
       size: 'xl',

--- a/src/pages/participantDetail/wrapperConfig.js
+++ b/src/pages/participantDetail/wrapperConfig.js
@@ -76,18 +76,23 @@ export const getBiospecimenWrapperConfig = (files = []) => {
     });
   }
 
-  return [
+  const config = [
     {
       container: 'paginatedTable',
       paginatedTable: true,
     },
-    {
+  ];
+
+  if (specimenIdsWithFiles.size > 0) {
+    config.push({
       container: 'buttons',
       size: 'xl',
       clsName: 'container_footer',
       items: biospecimenItems,
-    },
-  ];
+    });
+  }
+
+  return config;
 };
 
 // --------------- Files table wrapper config ---------------

--- a/src/pages/participantDetail/wrapperTheme.js
+++ b/src/pages/participantDetail/wrapperTheme.js
@@ -13,11 +13,9 @@ export const wrapperCustomTheme = {
         backgroundColor: '#E1EEEC',
       },
       '& img.add_selected_file_tooltip_icon': {
-        width: '18px',
-        height: '18px',
+        width: '17px',
         cursor: 'pointer',
         verticalAlign: 'top',
-        marginRight: '10px',
       },
     },
   },


### PR DESCRIPTION
- The "Add Files for Selected Biospecimens" button was extracted into a standalone `AddBiospecimenFilesButton` component with its own cart/query logic
- Button now disables itself when none of the selected biospecimens have associated files
- Biospecimen wrapper config changed from a static object to a function that accepts the files list and computes the config at render time
- `files` prop threaded from `ParticipantDetailView` down into `BiospecimensTable` to support the above check