### PR TITLE
CTDC-2155: Enforce no-metadata zero/disabled behavior and Rename participant count field under Clinical Data tab

### DIFF
--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -603,9 +603,6 @@ export const table = {
       display: true,
       tooltipText:
         "For each of the nodes listed below, the number of participants represented by one or more records within that node",
-      columnDefaultValues: {
-        0: " ",
-      },
     },
     {
       dataField: "recordCount",
@@ -614,9 +611,6 @@ export const table = {
       display: true,
       tooltipText:
         "For each of the nodes listed below, the total number of records within each node. Participants may have multiple/numerous records within certain nodes",
-      columnDefaultValues: {
-        0: " ",
-      },
     },
     {
       dataField: "csvDataRow",

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -597,7 +597,7 @@ export const table = {
       tooltipText: "sort",
     },
     {
-      dataField: "caseCount",
+      dataField: "participantCount",
       header: "Participants",
       sort: "asc",
       display: true,

--- a/src/components/PaginatedTable/Customize/CellView.js
+++ b/src/components/PaginatedTable/Customize/CellView.js
@@ -121,8 +121,8 @@ const DocumentDownloadView = ({
 
 // Custom Cell View
 export const CustomCellView = (props) => {
-  const { dataField, clinicalDataDescription, clinicalDataNode, caseCount, csvDataRow } = props;
-  const hasNoValues = caseCount === " " && defaultTo(csvDataRow, []).length === 0;
+  const { dataField, clinicalDataDescription, clinicalDataNode, participantCount, csvDataRow } = props;
+  const hasNoValues = participantCount === 0 && defaultTo(csvDataRow, []).length === 0;
 
   switch (dataField) {
     case customizeColumn.DOCUMENT_DOWNLOAD:

--- a/src/components/PaginatedTable/Customize/components/CsvDownload.js
+++ b/src/components/PaginatedTable/Customize/components/CsvDownload.js
@@ -4,7 +4,7 @@ import downloadIcon from "../../../../assets/icons/clinical_data_csv_icon.svg";
 import { downloadJson } from "../../../../pages/fileCentricCart/utils";
 import { ToolTip } from "../../../../bento-core";
 
-const CsvDownlaod = ({
+const CsvDownload = ({
   classes,
   csvDataRow = [],
   isCsvDisabled = false,
@@ -13,6 +13,17 @@ const CsvDownlaod = ({
 }) => {
   const handleCSVDownload = () => {
     downloadJson(csvDataRow, "", fileName, manifest);
+  };
+
+  const handleKeyDown = (event) => {
+    if (
+      event.key === "Enter" ||
+      event.key === " " ||
+      event.key === "Spacebar"
+    ) {
+      event.preventDefault();
+      handleCSVDownload();
+    }
   };
 
   if (isCsvDisabled) {
@@ -36,7 +47,11 @@ const CsvDownlaod = ({
         >
           <div
             className={classes.tooltipImageWrapper}
-            onClick={() => handleCSVDownload()}
+            role="button"
+            tabIndex={0}
+            aria-label="Download CSV for this clinical data node"
+            onClick={handleCSVDownload}
+            onKeyDown={handleKeyDown}
           >
             <img
               src={downloadIcon}
@@ -83,4 +98,4 @@ const styles = {
   },
 };
 
-export default withStyles(styles)(CsvDownlaod);
+export default withStyles(styles)(CsvDownload);

--- a/src/components/PaginatedTable/Customize/components/CsvDownload.js
+++ b/src/components/PaginatedTable/Customize/components/CsvDownload.js
@@ -1,45 +1,57 @@
-import React from 'react';
-import { withStyles } from '@material-ui/styles';
-import downloadIcon from '../../../../assets/icons/clinical_data_csv_icon.svg';
-import { downloadJson } from '../../../../pages/fileCentricCart/utils';
-import { ToolTip } from '../../../../bento-core';
+import React from "react";
+import { withStyles } from "@material-ui/styles";
+import downloadIcon from "../../../../assets/icons/clinical_data_csv_icon.svg";
+import { downloadJson } from "../../../../pages/fileCentricCart/utils";
+import { ToolTip } from "../../../../bento-core";
 
 const CsvDownlaod = ({
   classes,
   csvDataRow = [],
+  isCsvDisabled = false,
   manifest,
   fileName,
 }) => {
   const handleCSVDownload = () => {
-    downloadJson(csvDataRow, '', fileName, manifest);
+    downloadJson(csvDataRow, "", fileName, manifest);
   };
+
+  if (isCsvDisabled) {
+    return (
+      <div className={classes.disabledIconWrapper} aria-disabled="true">
+        <img
+          src={downloadIcon}
+          alt="csv download icon disabled"
+          className={classes.disabledIcon}
+        />
+      </div>
+    );
+  }
+
   return (
     <>
-      {
-        (csvDataRow?.length > 0) && (
-          <ToolTip
-            classes={{ tooltip: classes.tooltipText }}
-            title="Click to download the contents of this node"
+      {csvDataRow?.length > 0 && (
+        <ToolTip
+          classes={{ tooltip: classes.tooltipText }}
+          title="Click to download the contents of this node"
+        >
+          <div
+            className={classes.tooltipImageWrapper}
+            onClick={() => handleCSVDownload()}
           >
-            <div
-              className={classes.tooltipImageWrapper}
-              onClick={() => handleCSVDownload()}
-            >
-              <img
-                src={downloadIcon}
-                alt="csv download icon"
-                className={classes.icon}
-              />
-            </div>
-          </ToolTip>
-        )
-      }
+            <img
+              src={downloadIcon}
+              alt="csv download icon"
+              className={classes.icon}
+            />
+          </div>
+        </ToolTip>
+      )}
     </>
   );
 };
 
 const styles = {
-  tooltipText:{
+  tooltipText: {
     maxWidth: "175px",
     padding: "10px 15px",
 
@@ -47,18 +59,27 @@ const styles = {
     fontWeight: 600,
     fontSize: "13px",
     lineHeight: "19px",
-    color: '#223D4C',
+    color: "#223D4C",
     border: "1px solid #C3C3C3",
     boxShadow: "0px 4px 10px 0px #00000040",
     borderRadius: "5px",
     backgroundColor: "#FFFFFF",
   },
   icon: {
-    width: '24.71px',
-    height: '24.72px',
+    width: "24.71px",
+    height: "24.72px",
   },
   tooltipImageWrapper: {
-    cursor: 'pointer',
+    cursor: "pointer",
+  },
+  disabledIconWrapper: {
+    cursor: "not-allowed",
+  },
+  disabledIcon: {
+    width: "24.71px",
+    height: "24.72px",
+    opacity: 0.35,
+    filter: "grayscale(100%)",
   },
 };
 

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -146,7 +146,7 @@ const StudyDetailView = ({
                 <TabPanel value={currentTab} index={index} maxWidth="1800px">
                   <ClinicalDataController
                     dataCount={{
-                      caseCount: clinicalDataNodeParticipantCounts,
+                      participantCount: clinicalDataNodeParticipantCounts,
                       nodeCount: clinicalDataNodeCounts,
                     }}
                     study_id={study_id}

--- a/src/pages/studyDetail/views/clinical-data/ClinicalDataController.js
+++ b/src/pages/studyDetail/views/clinical-data/ClinicalDataController.js
@@ -33,7 +33,6 @@ const ClinicalDataController = ({
   classes,
   dataCount,
 }) => {
-
   const [description, setDescription] = useState(null);
   const [descriptionError, setDescriptionError] = useState(null);
 
@@ -88,14 +87,14 @@ const ClinicalDataController = ({
     return Array.isArray(nodeRows) && nodeRows.length > 0;
   });
 
-  const { caseCount, nodeCount } = dataCount;
+  const { participantCount, nodeCount } = dataCount;
 
   // Prepare table rows using pure function (easy to test)
   const rows = prepareTableRows({
     tableRows: table.rows,
     descriptions: description,
     nodeData,
-    caseCount,
+    participantCount,
     nodeCount,
     studyShortName: study_short_name,
     noClinicalMetadata: !hasClinicalMetadata,

--- a/src/pages/studyDetail/views/clinical-data/ClinicalDataController.js
+++ b/src/pages/studyDetail/views/clinical-data/ClinicalDataController.js
@@ -27,7 +27,13 @@ import {
  * @param {Object} props.classes - Material-UI styles
  * @param {Object} props.dataCount - Counts for participants and records
  */
-const ClinicalDataController = ({ study_id, study_short_name, classes, dataCount }) => {
+const ClinicalDataController = ({
+  study_id,
+  study_short_name,
+  classes,
+  dataCount,
+}) => {
+
   const [description, setDescription] = useState(null);
   const [descriptionError, setDescriptionError] = useState(null);
 
@@ -44,7 +50,7 @@ const ClinicalDataController = ({ study_id, study_short_name, classes, dataCount
 
   // Fetch clinical data via GraphQL
   const { data, loading, error } = useQuery(studyClinicalDataQuery, {
-    variables: { study_id: [study_id]},
+    variables: { study_id: [study_id] },
   });
 
   // Loading state - wait for both data sources
@@ -77,6 +83,11 @@ const ClinicalDataController = ({ study_id, study_short_name, classes, dataCount
   const clinicalTrialData = data?.clinicalTrialData?.at(0);
   const nodeData = { ...clinicalData, ...clinicalTrialData };
 
+  const hasClinicalMetadata = table.rows.some(({ csvDownload }) => {
+    const nodeRows = nodeData?.[csvDownload];
+    return Array.isArray(nodeRows) && nodeRows.length > 0;
+  });
+
   const { caseCount, nodeCount } = dataCount;
 
   // Prepare table rows using pure function (easy to test)
@@ -87,6 +98,7 @@ const ClinicalDataController = ({ study_id, study_short_name, classes, dataCount
     caseCount,
     nodeCount,
     studyShortName: study_short_name,
+    noClinicalMetadata: !hasClinicalMetadata,
   });
 
   return (

--- a/src/pages/studyDetail/views/clinical-data/ClinicalDataView.js
+++ b/src/pages/studyDetail/views/clinical-data/ClinicalDataView.js
@@ -11,6 +11,8 @@ const ClinicalDataView = ({ tblRows, classes, study_short_name }) => {
   const downloadAndZipCvsFiles = () => {
     downloadAndZipJson(tblRows, null, study_short_name);
   };
+  // Check if any row has data in its node property
+  const hasData = tblRows?.some(row => row.node && row.node.length > 0) || false;
 
   return (
     <div className={classes.container}>
@@ -26,7 +28,7 @@ const ClinicalDataView = ({ tblRows, classes, study_short_name }) => {
         </p>
       </div>
       <div className={classes.topDownloadBtn}>
-        <DownloadBtn handleCSVDownload={downloadAndZipCvsFiles} />
+        <DownloadBtn handleCSVDownload={downloadAndZipCvsFiles} disabled={!hasData} />
       </div>
       <div className={classes.paginatedTableWrapper}>
         <PaginatedTableView

--- a/src/pages/studyDetail/views/clinical-data/DataTheme.js
+++ b/src/pages/studyDetail/views/clinical-data/DataTheme.js
@@ -37,7 +37,7 @@ export const tblHeader = {
       },
       '&.clinicalDataDescription': {
       },
-      '&.caseCount': {
+      '&.participantCount': {
       },
       '&.recordCount': {
       },
@@ -215,7 +215,7 @@ const tblBody = {
       '&.clinicalDataDescription': {
         width: '68%',
       },
-      '&.caseCount': {
+      '&.participantCount': {
         '& p': {
           color: '#13344A',
           fontFamily: 'Nunito',

--- a/src/pages/studyDetail/views/clinical-data/clinicalDataTableUtils.js
+++ b/src/pages/studyDetail/views/clinical-data/clinicalDataTableUtils.js
@@ -27,6 +27,7 @@ export const generateFileName = (studyShortName, title) => {
  * @param {Object} params.caseCount - Participant counts by node type
  * @param {Object} params.nodeCount - Record counts by node type
  * @param {string} params.studyShortName - Study identifier for filename generation
+ * @param {boolean} params.noClinicalMetadata - True when all clinical and clinical trial metadata is absent
  * @returns {Array} Array of enriched row objects ready for display
  *
  * @example
@@ -46,16 +47,22 @@ export const prepareTableRows = ({
   caseCount,
   nodeCount,
   studyShortName,
+  noClinicalMetadata = false,
 }) => {
-  return tableRows.map((row) => ({
-    ...row,
-    clinicalDataNode: row.title,
-    clinicalDataDescription: descriptions[row.countKey] || "",
-    recordCount: nodeCount[row.countKey] || 0,
-    caseCount: caseCount[row.countKey] || 0,
-    csvDataRow: nodeData?.[row.csvDownload] || [],
-    fileName: generateFileName(studyShortName, row.title),
-    node: nodeData?.[row.csvDownload] || [],
-    metadata: row.manifest,
-  }));
+  return tableRows.map((row) => {
+    const rowNodeData = nodeData?.[row.csvDownload] || [];
+
+    return {
+      ...row,
+      clinicalDataNode: row.title,
+      clinicalDataDescription: descriptions[row.countKey] || "",
+      recordCount: noClinicalMetadata ? 0 : nodeCount[row.countKey] || 0,
+      caseCount: noClinicalMetadata ? 0 : caseCount[row.countKey] || 0,
+      csvDataRow: noClinicalMetadata ? [] : rowNodeData,
+      fileName: generateFileName(studyShortName, row.title),
+      node: noClinicalMetadata ? [] : rowNodeData,
+      isCsvDisabled: noClinicalMetadata,
+      metadata: row.manifest,
+    };
+  });
 };

--- a/src/pages/studyDetail/views/clinical-data/clinicalDataTableUtils.js
+++ b/src/pages/studyDetail/views/clinical-data/clinicalDataTableUtils.js
@@ -12,7 +12,7 @@
 export const generateFileName = (studyShortName, title) => {
   return `CTDC_Clinical_Data-${studyShortName}-${title.toUpperCase()}`.replace(
     /\s+/g,
-    "_"
+    "_",
   );
 };
 
@@ -24,7 +24,7 @@ export const generateFileName = (studyShortName, title) => {
  * @param {Array} params.tableRows - Table row configuration from studyDetailData
  * @param {Object} params.descriptions - Node descriptions keyed by node name
  * @param {Object} params.nodeData - Combined clinical and trial data
- * @param {Object} params.caseCount - Participant counts by node type
+ * @param {Object} params.participantCount - Participant counts by node type
  * @param {Object} params.nodeCount - Record counts by node type
  * @param {string} params.studyShortName - Study identifier for filename generation
  * @param {boolean} params.noClinicalMetadata - True when all clinical and clinical trial metadata is absent
@@ -35,7 +35,7 @@ export const generateFileName = (studyShortName, title) => {
  *   tableRows: table.rows,
  *   descriptions: { diagnosis: "Patient diagnosis info" },
  *   nodeData: { diagnosisNodeData: [...] },
- *   caseCount: { diagnosis: 150 },
+ *   participantCount: { diagnosis: 150 },
  *   nodeCount: { diagnosis: 200 },
  *   studyShortName: "CMB"
  * });
@@ -44,7 +44,7 @@ export const prepareTableRows = ({
   tableRows,
   descriptions,
   nodeData,
-  caseCount,
+  participantCount,
   nodeCount,
   studyShortName,
   noClinicalMetadata = false,
@@ -57,7 +57,9 @@ export const prepareTableRows = ({
       clinicalDataNode: row.title,
       clinicalDataDescription: descriptions[row.countKey] || "",
       recordCount: noClinicalMetadata ? 0 : nodeCount[row.countKey] || 0,
-      caseCount: noClinicalMetadata ? 0 : caseCount[row.countKey] || 0,
+      participantCount: noClinicalMetadata
+        ? 0
+        : participantCount[row.countKey] || 0,
       csvDataRow: noClinicalMetadata ? [] : rowNodeData,
       fileName: generateFileName(studyShortName, row.title),
       node: noClinicalMetadata ? [] : rowNodeData,

--- a/src/pages/studyDetail/views/clinical-data/components/downloadBtn.js
+++ b/src/pages/studyDetail/views/clinical-data/components/downloadBtn.js
@@ -4,12 +4,13 @@ import { ToolTip as Tooltip } from "../../../../../bento-core";
 import toolTipIcon from "../../../../../assets/study/questionMarkTooltip.svg";
 
 
-const DownloadBtn = ({ classes, handleCSVDownload }) => (
+const DownloadBtn = ({ classes, handleCSVDownload, disabled = false }) => (
   <div className={classes.downloadAllBtnContainer}>
     <Button
       variant="contained"
       classes={{ root: classes.downloadAllBtn }}
       onClick={handleCSVDownload}
+      disabled={disabled}
     >
       {"Download All"}
     </Button>


### PR DESCRIPTION
This PR updates the Study Detail Clinical Data tab to correctly handle no-metadata scenarios and align participant count naming.

### Changes
- Renamed Clinical Data participant field mapping from `caseCount` to `participantCount` across controller, row transformation, table column config, and theme selectors.
- Added metadata-presence detection in Clinical Data and passed a `noClinicalMetadata` flag to row prep logic.
- In no-metadata state, rows now force:
  - `participantCount = 0`
  - `recordCount = 0`
  - empty CSV row data
  - disabled CSV actions
- Disabled “Download All” when no row has node data.
- Removed zero-to-blank masking so `0` is rendered visibly.

### Result
- Data-present studies keep active download behavior and real counts.
- No-metadata studies show disabled download actions and visible zero counts consistently.