### PR TITLE
CTDC-2102: Add Study Facet item under Participant Facet Section and Refactor Study File Tab

### DIFF
--- a/src/bento/__tests__/studyDetailData.test.js
+++ b/src/bento/__tests__/studyDetailData.test.js
@@ -45,7 +45,7 @@ describe("studyFilesTableConfig", () => {
       true,
     );
     expect(studyFilesTableConfig.addFilesResponseKeys).toEqual([
-      "studyFileOverview",
+      "fileOverview",
       "data_file_uuid",
     ]);
   });

--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -31,6 +31,19 @@ export const facetSectionVariables = {
 };
 
 export const facetsConfig = [
+    {
+    section: CASES,
+    label: 'Study',
+    apiPath: 'participantCountByStudyShortName',
+    apiForFiltering: 'filterParticipantCountByStudyShortName',
+    datafield: 'study_short_name',
+    field: GROUP,
+    count: COUNT,
+    type: InputTypes.CHECKBOX,
+    sort_type: sortType.ALPHABET,
+    show: true,
+    defaultValue: DEFAULT_VALUE,
+  },
   {
     section: CASES,
     label: 'Diagnosis',

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -256,14 +256,14 @@ query search(
     
     ## Study Facet
     ## TODO: Uncomment the study facet queries when ready
-    # participantCountByStudyShortName {
-    #   group
-    #   subjects
-    # }
-    # filterParticipantCountByStudyShortName {
-    #   group
-    #   subjects
-    # }
+     participantCountByStudyShortName {
+      group
+       subjects
+     }
+     filterParticipantCountByStudyShortName {
+       group
+       subjects
+     }
 
     participantCountByStageOfDisease {
       group

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -34,7 +34,11 @@ export const externalLinkIcon = {
   src: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/externalLinkIcon.svg',
   alt: 'External link icon',
 };
-
+// --------------- Dahboard File and Study File default filters --------------
+export const defaultFilters = {
+  files: { association: ['biospecimen', 'participant'] },
+  studyFiles: { association: ['study'] },
+};
 
 // --------------- Tabs Header Data configuration --------------
 export const tabs = [
@@ -257,15 +261,14 @@ query search(
     }
     
     ## Study Facet
-    ## TODO: Uncomment the study facet queries when ready
-     participantCountByStudyShortName {
+    participantCountByStudyShortName {
       group
-       subjects
-     }
-     filterParticipantCountByStudyShortName {
-       group
-       subjects
-     }
+      subjects
+    }
+    filterParticipantCountByStudyShortName {
+      group
+      subjects
+    }
 
     participantCountByStageOfDisease {
       group
@@ -1048,6 +1051,24 @@ export const GET_STUDY_FILES_OVERVIEW_QUERY = gql`
   query studyFileOverviewQuery(
     $study_id: [String],
 
+    # $participant_id: [String],
+
+    $study_short_name: [String],
+    # $ctep_disease_term: [String],
+    # $stage_of_disease: [String],
+    # $tumor_grade: [String],
+    # $sex: [String],
+    # $race: [String],
+    # $ethnicity: [String],
+    # $carcinogen_exposure: [String],
+    # $targeted_therapy_string: [String], ## Replace: $targeted_therapy: [String],
+
+    # $anatomical_collection_site: [String],
+    # $tissue_category: [String],
+    # $assessment_timepoint: [String],
+    $association: [String],
+    $data_file_type: [String],
+    $data_file_format: [String],
 
     $study_short_name: [String],
     $association: [String],
@@ -1061,11 +1082,21 @@ export const GET_STUDY_FILES_OVERVIEW_QUERY = gql`
   ){
     studyFileOverview(
       study_id: $study_id
+      # participant_id: $participant_id
+
       study_short_name: $study_short_name
-      association: $association
-      ctep_disease_term: $ctep_disease_term
-      data_file_type: $data_file_type
-      data_file_format: $data_file_format
+      # ctep_disease_term: $ctep_disease_term
+      # stage_of_disease: $stage_of_disease
+      # tumor_grade: $tumor_grade
+      # sex: $sex
+      # race: $race
+      # ethnicity: $ethnicity
+      # carcinogen_exposure: $carcinogen_exposure
+      # targeted_therapy_string: $targeted_therapy_string ## Replace: targeted_therapy: $targeted_therapy
+
+      # anatomical_collection_site: $anatomical_collection_site
+      # tissue_category: $tissue_category
+      # assessment_timepoint: $assessment_timepoint
 
       first: $first
       offset: $offset
@@ -1090,7 +1121,21 @@ export const GET_FILE_IDS_FOR_SELECTED_STUDY_FILES = gql`
 query studyFileAddSelectedToCart(
   $data_file_uuid: [String],
   $study_id: [String],
+  # $participant_id: [String],
+
   $study_short_name: [String],
+  # $ctep_disease_term: [String],
+  # $stage_of_disease: [String],
+  # $tumor_grade: [String],
+  # $sex: [String],
+  # $race: [String],
+  # $ethnicity: [String],
+  # $carcinogen_exposure: [String],
+  # $targeted_therapy_string: [String], ## Replace: $targeted_therapy: [String],
+
+  # $anatomical_collection_site: [String],
+  # $tissue_category: [String],
+  # $assessment_timepoint: [String],
   $association: [String],
   $data_file_type: [String],
   $data_file_format: [String],
@@ -1447,7 +1492,7 @@ export const tabContainers = [
     dataField: 'dataFile',
     api: GET_FILES_OVERVIEW_QUERY,
     defaultFilters: {
-      association: ['biospecimen', 'participant'],
+      ...defaultFilters.files,
     },
     paginationAPIField: 'fileOverview',
     defaultSortField: 'data_file_name',
@@ -1602,11 +1647,11 @@ export const tabContainers = [
   {
     name: 'Study Files',
     dataField: 'dataStudyFile',
-    api: GET_STUDY_FILES_OVERVIEW_QUERY,
+    api: GET_FILES_OVERVIEW_QUERY, //GET_STUDY_FILES_OVERVIEW_QUERY,
     defaultFilters: {
-      association: ['study'],
+      ...defaultFilters.studyFiles
     },
-    paginationAPIField: 'studyFileOverview',
+    paginationAPIField: 'fileOverview', //'studyFileOverview',
     defaultSortField: 'data_file_name',
     defaultSortDirection: 'asc',
     count: 'numberOfStudyFiles',
@@ -1731,11 +1776,11 @@ export const tabContainers = [
 
     addFilesRequestVariableKey: 'data_file_uuid',
 
-    addFilesResponseKeys: ['studyFileOverview', 'data_file_uuid'],
-    addSelectedFilesQuery: GET_FILE_IDS_FOR_SELECTED_STUDY_FILES,
+    addFilesResponseKeys: ['fileOverview','data_file_uuid'], // ['studyFileOverview', 'data_file_uuid'],
+    addSelectedFilesQuery: GET_FILE_IDS_FOR_SELECTED_FILES, // GET_FILE_IDS_FOR_SELECTED_STUDY_FILES,
 
-    addAllFilesResponseKeys: ['studyFileOverview', 'data_file_uuid'],
-    addAllFileQuery: GET_ALL_FILE_IDS_FOR_STUDY_FILES,
+    addAllFilesResponseKeys: ['fileOverview', 'data_file_uuid'], // ['studyFileOverview', 'data_file_uuid'],
+    addAllFileQuery: GET_ALL_FILE_IDS_FOR_FILES, // GET_ALL_FILE_IDS_FOR_STUDY_FILES,
   },
 ];
 

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -653,6 +653,7 @@ export const GET_FILES_OVERVIEW_QUERY = gql`
     ){
       participant_id,
       study_accession
+      study_id
       data_file_name,
       data_file_format,
       data_file_type,

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -513,6 +513,7 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
       tumor_grade,
       age_at_enrollment,
       sex,
+      survival_status,
       race,
       ethnicity,
       carcinogen_exposure,

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -993,24 +993,55 @@ export const GET_FILE_IDS_FROM_FILE_NAME = gql`
   }`;
 
 // --------------- GraphQL Query - Retrieve Study Files tab details --------------
+// TODO: Add the rest of the filters to the Study Files tab query when ready
 export const GET_STUDY_FILES_OVERVIEW_QUERY = gql`
   query studyFileOverviewQuery(
-    $study_short_name: [String],
     $study_id: [String],
-    # $study_short_name: [String],
+    # $participant_id: [String],
+
+    $study_short_name: [String],
+    # $ctep_disease_term: [String],
+    # $stage_of_disease: [String],
+    # $tumor_grade: [String],
+    # $sex: [String],
+    # $race: [String],
+    # $ethnicity: [String],
+    # $carcinogen_exposure: [String],
+    # $targeted_therapy_string: [String], ## Replace: $targeted_therapy: [String],
+
+    # $anatomical_collection_site: [String],
+    # $tissue_category: [String],
+    # $assessment_timepoint: [String],
+
     $data_file_type: [String],
     $data_file_format: [String],
+    
     $first: Int,
-    $offset: Int,
-    $order_by: String,
-    $sort_direction: String
+    $offset: Int = 0, 
+    $order_by: String = "data_file_name",
+    $sort_direction: String = "asc"
   ){
     studyFileOverview(
-      study_short_name: $study_short_name
       study_id: $study_id
-      # study_short_name: $study_short_name
+      # participant_id: $participant_id
+
+      study_short_name: $study_short_name
+      # ctep_disease_term: $ctep_disease_term
+      # stage_of_disease: $stage_of_disease
+      # tumor_grade: $tumor_grade
+      # sex: $sex
+      # race: $race
+      # ethnicity: $ethnicity
+      # carcinogen_exposure: $carcinogen_exposure
+      # targeted_therapy_string: $targeted_therapy_string ## Replace: targeted_therapy: $targeted_therapy
+
+      # anatomical_collection_site: $anatomical_collection_site
+      # tissue_category: $tissue_category
+      # assessment_timepoint: $assessment_timepoint
+
       data_file_type: $data_file_type
       data_file_format: $data_file_format
+
       first: $first
       offset: $offset
       order_by: $order_by
@@ -1029,13 +1060,30 @@ export const GET_STUDY_FILES_OVERVIEW_QUERY = gql`
 `;
 
 // --------------- GraphQL Query - "ADD SELECTED FILES" under Study Files tab ---------------
+// TODO: Add the rest of the filters to the Study Files tab query when ready
 export const GET_FILE_IDS_FOR_SELECTED_STUDY_FILES = gql`
 query studyFileAddSelectedToCart(
   $data_file_uuid: [String],
-  $study_short_name: [String],
   $study_id: [String],
+  # $participant_id: [String],
+
+  $study_short_name: [String],
+  # $ctep_disease_term: [String],
+  # $stage_of_disease: [String],
+  # $tumor_grade: [String],
+  # $sex: [String],
+  # $race: [String],
+  # $ethnicity: [String],
+  # $carcinogen_exposure: [String],
+  # $targeted_therapy_string: [String], ## Replace: $targeted_therapy: [String],
+
+  # $anatomical_collection_site: [String],
+  # $tissue_category: [String],
+  # $assessment_timepoint: [String],
+
   $data_file_type: [String],
   $data_file_format: [String],
+  
   $first: Int,
   $offset: Int = 0,
   $order_by: String = "data_file_uuid",
@@ -1043,10 +1091,26 @@ query studyFileAddSelectedToCart(
 ){
   studyFileOverview(
     data_file_uuid: $data_file_uuid
-    study_short_name: $study_short_name
     study_id: $study_id
+    # participant_id: $participant_id
+
+    study_short_name: $study_short_name
+    # ctep_disease_term: $ctep_disease_term
+    # stage_of_disease: $stage_of_disease
+    # tumor_grade: $tumor_grade
+    # sex: $sex
+    # race: $race
+    # ethnicity: $ethnicity
+    # carcinogen_exposure: $carcinogen_exposure
+    # targeted_therapy_string: $targeted_therapy_string ## Replace: targeted_therapy: $targeted_therapy
+
+    # anatomical_collection_site: $anatomical_collection_site
+    # tissue_category: $tissue_category
+    # assessment_timepoint: $assessment_timepoint
+
     data_file_type: $data_file_type
     data_file_format: $data_file_format
+
     first: $first
     offset: $offset
     order_by: $order_by
@@ -1058,22 +1122,55 @@ query studyFileAddSelectedToCart(
 `;
 
 // --------------- GraphQL Query - "ADD ALL FILES" under Study Files tab ---------------
+// TODO: Add the rest of the filters to the Study Files tab query when ready
 export const GET_ALL_FILE_IDS_FOR_STUDY_FILES = gql`
 query studyFileAddAllToCart(
-  $study_short_name: [String],
   $study_id: [String],
+  # $participant_id: [String],
+
+  $study_short_name: [String],
+  # $ctep_disease_term: [String],
+  # $stage_of_disease: [String],
+  # $tumor_grade: [String],
+  # $sex: [String],
+  # $race: [String],
+  # $ethnicity: [String],
+  # $carcinogen_exposure: [String],
+  # $targeted_therapy_string: [String], ## Replace: $targeted_therapy: [String],
+
+  # $anatomical_collection_site: [String],
+  # $tissue_category: [String],
+  # $assessment_timepoint: [String],
+
   $data_file_type: [String],
   $data_file_format: [String],
+  
   $first: Int,
   $offset: Int = 0,
   $order_by: String = "data_file_uuid",
   $sort_direction: String = "asc"
 ){
   studyFileOverview(
-    study_short_name: $study_short_name
     study_id: $study_id
+    # participant_id: $participant_id
+
+    study_short_name: $study_short_name
+    # ctep_disease_term: $ctep_disease_term
+    # stage_of_disease: $stage_of_disease
+    # tumor_grade: $tumor_grade
+    # sex: $sex
+    # race: $race
+    # ethnicity: $ethnicity
+    # carcinogen_exposure: $carcinogen_exposure
+    # targeted_therapy_string: $targeted_therapy_string ## Replace: targeted_therapy: $targeted_therapy
+
+    # anatomical_collection_site: $anatomical_collection_site
+    # tissue_category: $tissue_category
+    # assessment_timepoint: $assessment_timepoint
+
     data_file_type: $data_file_type
     data_file_format: $data_file_format
+
     first: $first
     offset: $offset
     order_by: $order_by

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -409,6 +409,8 @@ query search(
   }
   filesTabCount: searchParticipants(
     participant_id: $participant_id
+    study_short_name: $study_short_name
+
     ctep_disease_term: $ctep_disease_term
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
@@ -430,6 +432,8 @@ query search(
   }
   studyFilesTabCount: searchParticipants(
     participant_id: $participant_id
+    study_short_name: $study_short_name
+    
     ctep_disease_term: $ctep_disease_term
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -34,7 +34,7 @@ export const externalLinkIcon = {
   src: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/externalLinkIcon.svg',
   alt: 'External link icon',
 };
-// --------------- Dahboard File and Study File default filters --------------
+// --------------- Dashboard File and Study File default filters --------------
 export const defaultFilters = {
   files: { association: ['biospecimen', 'participant'] },
   studyFiles: { association: ['study'] },

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -101,6 +101,7 @@ export const tabIndex = [
 export const TARGETED_THERAPY_QUERY = gql`
 query search_for_targeted_therapy (
   $participant_id: [String],
+  $study_short_name: [String],
   $ctep_disease_term: [String],
   $stage_of_disease: [String],
   $tumor_grade: [String], 
@@ -120,6 +121,7 @@ query search_for_targeted_therapy (
 ) {
   searchParticipants(
     participant_id: $participant_id
+    study_short_name: $study_short_name
     ctep_disease_term: $ctep_disease_term
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
@@ -172,6 +174,7 @@ query search_for_targeted_therapy (
 export const DASHBOARD_QUERY_NEW = gql`
 query search(
   $participant_id: [String],
+  $study_short_name: [String],
   $ctep_disease_term: [String],
   $stage_of_disease: [String],
   $tumor_grade: [String],
@@ -191,6 +194,7 @@ query search(
 ) {
   searchParticipants(
     participant_id: $participant_id
+    study_short_name: $study_short_name
     ctep_disease_term: $ctep_disease_term
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
@@ -249,6 +253,18 @@ query search(
       }
       __typename
     }
+    
+    ## Study Facet
+    ## TODO: Uncomment the study facet queries when ready
+    # participantCountByStudyShortName {
+    #   group
+    #   subjects
+    # }
+    # filterParticipantCountByStudyShortName {
+    #   group
+    #   subjects
+    # }
+
     participantCountByStageOfDisease {
       group
       subjects
@@ -389,9 +405,11 @@ query search(
 }
 `;
 
+// --------------- GraphQL Query - Retrieve Participants tab details --------------
 export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
   query participantOverview(
     $participant_id: [String],
+    $study_short_name: [String],
     $ctep_disease_term: [String],
     $stage_of_disease: [String],
     $tumor_grade: [String],
@@ -416,6 +434,7 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
   ){
     participantOverview(
       participant_id: $participant_id
+      study_short_name: $study_short_name
       ctep_disease_term: $ctep_disease_term
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
@@ -457,10 +476,11 @@ export const GET_PARTICIPANTS_OVERVIEW_QUERY = gql`
     }
   }
 `;
-
+// --------------- GraphQL Query - Retrieve Biospecimens tab details --------------
 export const GET_BIOSPECIMENS_OVERVIEW_QUERY = gql`
   query biospecimenOverview(
     $participant_id: [String],
+    $study_short_name: [String],
     $ctep_disease_term: [String],
     $stage_of_disease: [String],
     $tumor_grade: [String],
@@ -485,6 +505,7 @@ export const GET_BIOSPECIMENS_OVERVIEW_QUERY = gql`
   ){
     biospecimenOverview(
       participant_id: $participant_id
+      study_short_name: $study_short_name
       ctep_disease_term: $ctep_disease_term
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
@@ -525,10 +546,11 @@ export const GET_BIOSPECIMENS_OVERVIEW_QUERY = gql`
     }
   }
 `;
-
+// --------------- GraphQL Query - Retrieve Files tab details --------------
 export const GET_FILES_OVERVIEW_QUERY = gql`
   query fileOverview(
     $participant_id: [String],
+    $study_short_name: [String],
     $ctep_disease_term: [String],
     $stage_of_disease: [String],
     $tumor_grade: [String],
@@ -553,6 +575,7 @@ export const GET_FILES_OVERVIEW_QUERY = gql`
   ){
     fileOverview(
       participant_id: $participant_id
+      study_short_name: $study_short_name
       ctep_disease_term: $ctep_disease_term
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
@@ -594,6 +617,7 @@ export const GET_FILES_OVERVIEW_QUERY = gql`
 export const GET_FILE_IDS_FOR_SELECTED_PARTICIPANTS = gql`
 query participant_data_files(
   $participant_id: [String],
+  $study_short_name: [String],
   $ctep_disease_term: [String],
   $stage_of_disease: [String],
   $tumor_grade: [String],
@@ -618,6 +642,7 @@ query participant_data_files(
 ) {
   participant_data_files(
       participant_id: $participant_id
+      study_short_name: $study_short_name
       ctep_disease_term: $ctep_disease_term
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
@@ -652,6 +677,7 @@ query biospecimenAddAllToCart(
   $specimen_record_id: [String], # Helps in adding the selected Biospecimen(s)-files to the cart
 
   $participant_id: [String],
+  $study_short_name: [String],
   $ctep_disease_term: [String],
   $stage_of_disease: [String],
   $tumor_grade: [String],
@@ -678,6 +704,7 @@ query biospecimenAddAllToCart(
     specimen_record_id: $specimen_record_id
 
     participant_id: $participant_id
+    study_short_name: $study_short_name
     ctep_disease_term: $ctep_disease_term
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
@@ -711,6 +738,7 @@ query fileAddSelectedToCart(
   $data_file_uuid: [String], # Helps in adding the selected files to the cart
 
   $participant_id: [String],
+  $study_short_name: [String],
   $ctep_disease_term: [String],
   $stage_of_disease: [String],
   $tumor_grade: [String],
@@ -734,9 +762,10 @@ query fileAddSelectedToCart(
   $sort_direction: String = "asc"
  ){
   fileOverview(
-    data_file_uuid: $data_file_uuid,
+    data_file_uuid: $data_file_uuid
     
     participant_id: $participant_id
+    study_short_name: $study_short_name
     ctep_disease_term: $ctep_disease_term
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
@@ -768,6 +797,7 @@ query fileAddSelectedToCart(
 export const GET_ALL_FILE_IDS_FOR_PARTICIPANTS = gql`
 query participant_data_files(
   $participant_id: [String],
+  $study_short_name: [String],
   $ctep_disease_term: [String],
   $stage_of_disease: [String],
   $tumor_grade: [String],
@@ -792,6 +822,7 @@ query participant_data_files(
 ) {
   participant_data_files(
       participant_id: $participant_id
+      study_short_name: $study_short_name
       ctep_disease_term: $ctep_disease_term
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
@@ -823,6 +854,7 @@ query participant_data_files(
 export const GET_ALL_FILE_IDS_FOR_BIOSPECIMENS = gql`
   query biospecimenAddAllToCart(
     $participant_id: [String],
+    $study_short_name: [String],
     $ctep_disease_term: [String],
     $stage_of_disease: [String],
     $tumor_grade: [String],
@@ -847,6 +879,7 @@ export const GET_ALL_FILE_IDS_FOR_BIOSPECIMENS = gql`
   ){
     biospecimen_data_files(
       participant_id: $participant_id
+      study_short_name: $study_short_name
       ctep_disease_term: $ctep_disease_term
       stage_of_disease: $stage_of_disease
       tumor_grade: $tumor_grade
@@ -878,6 +911,7 @@ export const GET_ALL_FILE_IDS_FOR_BIOSPECIMENS = gql`
 export const GET_ALL_FILE_IDS_FOR_FILES = gql`
 query fileAddAllToCart(
   $participant_id: [String],
+  $study_short_name: [String],
   $ctep_disease_term: [String],
   $stage_of_disease: [String],
   $tumor_grade: [String],
@@ -902,6 +936,7 @@ query fileAddAllToCart(
  ){
   fileOverview(
     participant_id: $participant_id
+    study_short_name: $study_short_name
     ctep_disease_term: $ctep_disease_term
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
@@ -962,6 +997,7 @@ export const GET_STUDY_FILES_OVERVIEW_QUERY = gql`
   query studyFileOverviewQuery(
     $study_short_name: [String],
     $study_id: [String],
+    # $study_short_name: [String],
     $data_file_type: [String],
     $data_file_format: [String],
     $first: Int,
@@ -972,6 +1008,7 @@ export const GET_STUDY_FILES_OVERVIEW_QUERY = gql`
     studyFileOverview(
       study_short_name: $study_short_name
       study_id: $study_id
+      # study_short_name: $study_short_name
       data_file_type: $data_file_type
       data_file_format: $data_file_format
       first: $first

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -433,7 +433,7 @@ query search(
   studyFilesTabCount: searchParticipants(
     participant_id: $participant_id
     study_short_name: $study_short_name
-    
+
     ctep_disease_term: $ctep_disease_term
     stage_of_disease: $stage_of_disease
     tumor_grade: $tumor_grade
@@ -1074,11 +1074,6 @@ export const GET_STUDY_FILES_OVERVIEW_QUERY = gql`
     $data_file_type: [String],
     $data_file_format: [String],
 
-    $study_short_name: [String],
-    $association: [String],
-    $data_file_type: [String],
-    $data_file_format: [String],
-    $ctep_disease_term: [String],
     $first: Int,
     $offset: Int = 0, 
     $order_by: String = "data_file_name",

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -186,6 +186,8 @@ query search(
   $tissue_category: [String],
   $assessment_timepoint: [String],
 
+  $files_association: [String],
+  $study_association: [String],
   $data_file_type: [String],
   $data_file_format: [String]
 ) {
@@ -386,6 +388,48 @@ query search(
       subjects
     }
   }
+  filesTabCount: searchParticipants(
+    participant_id: $participant_id
+    ctep_disease_term: $ctep_disease_term
+    stage_of_disease: $stage_of_disease
+    tumor_grade: $tumor_grade
+    sex: $sex
+    race: $race
+    ethnicity: $ethnicity
+    carcinogen_exposure: $carcinogen_exposure
+    targeted_therapy_string: $targeted_therapy_string
+
+    anatomical_collection_site: $anatomical_collection_site
+    tissue_category: $tissue_category
+    assessment_timepoint: $assessment_timepoint
+
+    association: $files_association
+    data_file_type: $data_file_type
+    data_file_format: $data_file_format
+  ) {
+    numberOfFiles
+  }
+  studyFilesTabCount: searchParticipants(
+    participant_id: $participant_id
+    ctep_disease_term: $ctep_disease_term
+    stage_of_disease: $stage_of_disease
+    tumor_grade: $tumor_grade
+    sex: $sex
+    race: $race
+    ethnicity: $ethnicity
+    carcinogen_exposure: $carcinogen_exposure
+    targeted_therapy_string: $targeted_therapy_string
+
+    anatomical_collection_site: $anatomical_collection_site
+    tissue_category: $tissue_category
+    assessment_timepoint: $assessment_timepoint
+
+    association: $study_association
+    data_file_type: $data_file_type
+    data_file_format: $data_file_format
+  ) {
+    numberOfStudyFiles
+  }
 }
 `;
 
@@ -543,6 +587,7 @@ export const GET_FILES_OVERVIEW_QUERY = gql`
     $tissue_category: [String],
     $assessment_timepoint: [String],
 
+    $association: [String],
     $data_file_type: [String],
     $data_file_format: [String],
 
@@ -567,6 +612,7 @@ export const GET_FILES_OVERVIEW_QUERY = gql`
       tissue_category: $tissue_category
       assessment_timepoint: $assessment_timepoint
 
+      association: $association
       data_file_type: $data_file_type
       data_file_format: $data_file_format
 
@@ -725,6 +771,7 @@ query fileAddSelectedToCart(
   $tissue_category: [String],
   $assessment_timepoint: [String],
 
+  $association: [String],
   $data_file_type: [String],
   $data_file_format: [String],
 
@@ -751,6 +798,7 @@ query fileAddSelectedToCart(
     tissue_category: $tissue_category
     assessment_timepoint: $assessment_timepoint
 
+    association: $association
     data_file_type: $data_file_type
     data_file_format: $data_file_format
 
@@ -892,6 +940,7 @@ query fileAddAllToCart(
   $tissue_category: [String],
   $assessment_timepoint: [String],
 
+  $association: [String],
   $data_file_type: [String],
   $data_file_format: [String],
   
@@ -916,6 +965,7 @@ query fileAddAllToCart(
     tissue_category: $tissue_category
     assessment_timepoint: $assessment_timepoint
 
+    association: $association
     data_file_type: $data_file_type
     data_file_format: $data_file_format
 
@@ -962,8 +1012,10 @@ export const GET_STUDY_FILES_OVERVIEW_QUERY = gql`
   query studyFileOverviewQuery(
     $study_short_name: [String],
     $study_id: [String],
+    $association: [String],
     $data_file_type: [String],
     $data_file_format: [String],
+    $ctep_disease_term: [String],
     $first: Int,
     $offset: Int,
     $order_by: String,
@@ -972,6 +1024,8 @@ export const GET_STUDY_FILES_OVERVIEW_QUERY = gql`
     studyFileOverview(
       study_short_name: $study_short_name
       study_id: $study_id
+      association: $association
+      ctep_disease_term: $ctep_disease_term
       data_file_type: $data_file_type
       data_file_format: $data_file_format
       first: $first
@@ -997,8 +1051,10 @@ query studyFileAddSelectedToCart(
   $data_file_uuid: [String],
   $study_short_name: [String],
   $study_id: [String],
+  $association: [String],
   $data_file_type: [String],
   $data_file_format: [String],
+  
   $first: Int,
   $offset: Int = 0,
   $order_by: String = "data_file_uuid",
@@ -1008,6 +1064,7 @@ query studyFileAddSelectedToCart(
     data_file_uuid: $data_file_uuid
     study_short_name: $study_short_name
     study_id: $study_id
+    association: $association
     data_file_type: $data_file_type
     data_file_format: $data_file_format
     first: $first
@@ -1025,6 +1082,7 @@ export const GET_ALL_FILE_IDS_FOR_STUDY_FILES = gql`
 query studyFileAddAllToCart(
   $study_short_name: [String],
   $study_id: [String],
+  $association: [String],
   $data_file_type: [String],
   $data_file_format: [String],
   $first: Int,
@@ -1035,6 +1093,7 @@ query studyFileAddAllToCart(
   studyFileOverview(
     study_short_name: $study_short_name
     study_id: $study_id
+    association: $association
     data_file_type: $data_file_type
     data_file_format: $data_file_format
     first: $first
@@ -1301,6 +1360,9 @@ export const tabContainers = [
     name: 'Files',
     dataField: 'dataFile',
     api: GET_FILES_OVERVIEW_QUERY,
+    defaultFilters: {
+      association: ['biospecimen', 'participant'],
+    },
     paginationAPIField: 'fileOverview',
     defaultSortField: 'data_file_name',
     defaultSortDirection: 'asc',
@@ -1455,6 +1517,9 @@ export const tabContainers = [
     name: 'Study Files',
     dataField: 'dataStudyFile',
     api: GET_STUDY_FILES_OVERVIEW_QUERY,
+    defaultFilters: {
+      association: ['study'],
+    },
     paginationAPIField: 'studyFileOverview',
     defaultSortField: 'data_file_name',
     defaultSortDirection: 'asc',

--- a/src/bento/dashboardTabData.test.js
+++ b/src/bento/dashboardTabData.test.js
@@ -2,67 +2,93 @@ jest.mock("../utils/graphqlClient", () => ({
   client: { query: jest.fn(), mutate: jest.fn() },
 }));
 
-import { tabContainers, tabs } from './dashboardTabData';
+import { tabContainers, tabs } from "./dashboardTabData";
 
-describe('Study Files tab configuration', () => {
-  const studyFilesTab = tabs.find((t) => t.id === 'study_file_tab');
-  const studyFilesContainer = tabContainers.find((t) => t.id === 'study_file_tab');
+describe("Study Files tab configuration", () => {
+  const studyFilesTab = tabs.find((t) => t.id === "study_file_tab");
+  const studyFilesContainer = tabContainers.find(
+    (t) => t.id === "study_file_tab",
+  );
 
-  describe('tabs entry', () => {
-    it('should exist in the tabs array', () => {
+  describe("tabs entry", () => {
+    it("should exist in the tabs array", () => {
       expect(studyFilesTab).toBeDefined();
     });
 
-    it('should have correct title', () => {
-      expect(studyFilesTab.title).toBe('Study Files');
+    it("should have correct title", () => {
+      expect(studyFilesTab.title).toBe("Study Files");
     });
 
-    it('should reference numberOfStudyFiles for count', () => {
-      expect(studyFilesTab.count).toBe('numberOfStudyFiles');
+    it("should reference numberOfStudyFiles for count", () => {
+      expect(studyFilesTab.count).toBe("numberOfStudyFiles");
     });
   });
 
-  describe('tabContainers entry', () => {
-    it('should exist in the tabContainers array', () => {
+  describe("tabContainers entry", () => {
+    it("should exist in the tabContainers array", () => {
       expect(studyFilesContainer).toBeDefined();
     });
 
-    it('should use studyFileOverview as paginationAPIField', () => {
-      expect(studyFilesContainer.paginationAPIField).toBe('studyFileOverview');
+    it("should use fileOverview as paginationAPIField", () => {
+      expect(studyFilesContainer.paginationAPIField).toBe("fileOverview");
     });
 
-    it('should use data_file_uuid as dataKey', () => {
-      expect(studyFilesContainer.dataKey).toBe('data_file_uuid');
+    it("should use data_file_uuid as dataKey", () => {
+      expect(studyFilesContainer.dataKey).toBe("data_file_uuid");
     });
 
-    it('should always apply association filter as study', () => {
-      expect(studyFilesContainer.defaultFilters).toEqual({ association: ['study'] });
-    });
-
-    it('should have selectableRows enabled', () => {
+    it("should have selectableRows enabled", () => {
       expect(studyFilesContainer.selectableRows).toBe(true);
     });
 
-    it('should have View Columns enabled in extendedViewConfig', () => {
-      expect(studyFilesContainer.extendedViewConfig.manageViewColumns).toBeDefined();
-      expect(studyFilesContainer.extendedViewConfig.manageViewColumns.title).toBe('View Columns');
+    it("should have View Columns enabled in extendedViewConfig", () => {
+      expect(
+        studyFilesContainer.extendedViewConfig.manageViewColumns,
+      ).toBeDefined();
+      expect(
+        studyFilesContainer.extendedViewConfig.manageViewColumns.title,
+      ).toBe("View Columns");
     });
 
-    it('should have CSV download configured', () => {
-      expect(studyFilesContainer.extendedViewConfig.download.downloadFileName).toBe('CTDC_Study_Files_download');
+    it("should have CSV download configured", () => {
+      expect(
+        studyFilesContainer.extendedViewConfig.download.downloadFileName,
+      ).toBe("CTDC_Study_Files_download");
     });
   });
 
-  describe('columns', () => {
+  describe("defaultFilters", () => {
+    it("should have association filter with study only", () => {
+      expect(studyFilesContainer.defaultFilters).toEqual({
+        association: ["study"],
+      });
+    });
+
+    it("should have association array with exactly 1 value", () => {
+      expect(studyFilesContainer.defaultFilters.association).toHaveLength(1);
+    });
+
+    it("should include study in association filter", () => {
+      expect(studyFilesContainer.defaultFilters.association).toContain("study");
+    });
+  });
+
+  describe("columns", () => {
     const columns = studyFilesContainer.columns;
 
-    it('should have a checkbox column', () => {
-      const checkbox = columns.find((c) => c.cellType === 'CHECKBOX');
+    it("should have a checkbox column", () => {
+      const checkbox = columns.find((c) => c.cellType === "CHECKBOX");
       expect(checkbox).toBeDefined();
     });
 
-    it('should have File Name, File Type, Format, Size, Description columns displayed', () => {
-      const expectedFields = ['data_file_name', 'data_file_type', 'data_file_format', 'data_file_size', 'data_file_description'];
+    it("should have File Name, File Type, Format, Size, Description columns displayed", () => {
+      const expectedFields = [
+        "data_file_name",
+        "data_file_type",
+        "data_file_format",
+        "data_file_size",
+        "data_file_description",
+      ];
       expectedFields.forEach((field) => {
         const col = columns.find((c) => c.dataField === field);
         expect(col).toBeDefined();
@@ -70,68 +96,147 @@ describe('Study Files tab configuration', () => {
       });
     });
 
-    it('should have Access column with unique dataField', () => {
-      const accessCol = columns.find((c) => c.header === 'Access');
+    it("should have Access column with unique dataField", () => {
+      const accessCol = columns.find((c) => c.header === "Access");
       expect(accessCol).toBeDefined();
-      expect(accessCol.dataField).toBe('access');
+      expect(accessCol.dataField).toBe("access");
       expect(accessCol.downloadDocument).toBe(true);
     });
 
-    it('Access column should reference data_file_uuid via documentDownloadProps', () => {
-      const accessCol = columns.find((c) => c.header === 'Access');
-      expect(accessCol.documentDownloadProps.fileLocationColumn).toBe('data_file_uuid');
+    it("Access column should reference data_file_uuid via documentDownloadProps", () => {
+      const accessCol = columns.find((c) => c.header === "Access");
+      expect(accessCol.documentDownloadProps.fileLocationColumn).toBe(
+        "data_file_uuid",
+      );
     });
 
-    it('should have Study Accession column linked to study detail', () => {
-      const col = columns.find((c) => c.dataField === 'study_accession');
+    it("should have Study Accession column linked to study detail", () => {
+      const col = columns.find((c) => c.dataField === "study_accession");
       expect(col).toBeDefined();
       expect(col.display).toBe(true);
-      expect(col.linkAttr.rootPath).toBe('/study');
+      expect(col.linkAttr.rootPath).toBe("/study");
     });
 
-    it('should have File UUID column hidden by default but toggleable', () => {
-      const uuidCol = columns.find((c) => c.header === 'File UUID');
+    it("should have File UUID column hidden by default but toggleable", () => {
+      const uuidCol = columns.find((c) => c.header === "File UUID");
       expect(uuidCol).toBeDefined();
-      expect(uuidCol.dataField).toBe('data_file_uuid');
+      expect(uuidCol.dataField).toBe("data_file_uuid");
       expect(uuidCol.display).toBe(false);
       expect(uuidCol.hiddenByDefault).toBe(true);
     });
 
-    it('Access and File UUID columns should have different dataFields', () => {
-      const accessCol = columns.find((c) => c.header === 'Access');
-      const uuidCol = columns.find((c) => c.header === 'File UUID');
+    it("Access and File UUID columns should have different dataFields", () => {
+      const accessCol = columns.find((c) => c.header === "Access");
+      const uuidCol = columns.find((c) => c.header === "File UUID");
       expect(accessCol.dataField).not.toBe(uuidCol.dataField);
     });
   });
 
-  describe('cart configuration', () => {
-    it('should use data_file_uuid as addFilesRequestVariableKey', () => {
-      expect(studyFilesContainer.addFilesRequestVariableKey).toBe('data_file_uuid');
+  describe("cart configuration", () => {
+    it("should use data_file_uuid as addFilesRequestVariableKey", () => {
+      expect(studyFilesContainer.addFilesRequestVariableKey).toBe(
+        "data_file_uuid",
+      );
     });
 
-    it('should have correct addFilesResponseKeys', () => {
-      expect(studyFilesContainer.addFilesResponseKeys).toEqual(['studyFileOverview', 'data_file_uuid']);
+    it("should have correct addFilesResponseKeys", () => {
+      expect(studyFilesContainer.addFilesResponseKeys).toEqual([
+        "fileOverview",
+        "data_file_uuid",
+      ]);
     });
 
-    it('should have correct addAllFilesResponseKeys', () => {
-      expect(studyFilesContainer.addAllFilesResponseKeys).toEqual(['studyFileOverview', 'data_file_uuid']);
+    it("should have correct addAllFilesResponseKeys", () => {
+      expect(studyFilesContainer.addAllFilesResponseKeys).toEqual([
+        "fileOverview",
+        "data_file_uuid",
+      ]);
     });
   });
 });
 
-describe('Files tab configuration', () => {
-  const filesTab = tabs.find((t) => t.id === 'file_tab');
-  const filesContainer = tabContainers.find((t) => t.id === 'file_tab');
+describe("Files tab configuration", () => {
+  const filesTab = tabs.find((t) => t.id === "file_tab");
+  const filesContainer = tabContainers.find((t) => t.id === "file_tab");
 
-  it('should exist in the tabs array', () => {
-    expect(filesTab).toBeDefined();
+  describe("tabs entry", () => {
+    it("should exist in the tabs array", () => {
+      expect(filesTab).toBeDefined();
+    });
+
+    it("should reference numberOfFiles for count", () => {
+      expect(filesTab.count).toBe("numberOfFiles");
+    });
   });
 
-  it('should reference numberOfFiles for count', () => {
-    expect(filesTab.count).toBe('numberOfFiles');
+  describe("tabContainers entry", () => {
+    it("should exist in the tabContainers array", () => {
+      expect(filesContainer).toBeDefined();
+    });
+
+    it("should use fileOverview as paginationAPIField", () => {
+      expect(filesContainer.paginationAPIField).toBe("fileOverview");
+    });
   });
 
-  it('should always apply association filter as biospecimen and participant', () => {
-    expect(filesContainer.defaultFilters).toEqual({ association: ['biospecimen', 'participant'] });
+  describe("defaultFilters", () => {
+    it("should have association filter with biospecimen and participant", () => {
+      expect(filesContainer.defaultFilters).toEqual({
+        association: ["biospecimen", "participant"],
+      });
+    });
+
+    it("should have association array with exactly 2 values", () => {
+      expect(filesContainer.defaultFilters.association).toHaveLength(2);
+    });
+
+    it("should include biospecimen in association filter", () => {
+      expect(filesContainer.defaultFilters.association).toContain(
+        "biospecimen",
+      );
+    });
+
+    it("should include participant in association filter", () => {
+      expect(filesContainer.defaultFilters.association).toContain(
+        "participant",
+      );
+    });
+  });
+});
+
+describe("defaultFilters comparison between tabs", () => {
+  const filesContainer = tabContainers.find((t) => t.id === "file_tab");
+  const studyFilesContainer = tabContainers.find(
+    (t) => t.id === "study_file_tab",
+  );
+
+  it("both tabs should use fileOverview API with different association filters", () => {
+    expect(filesContainer.paginationAPIField).toBe("fileOverview");
+    expect(studyFilesContainer.paginationAPIField).toBe("fileOverview");
+    expect(filesContainer.defaultFilters.association).not.toEqual(
+      studyFilesContainer.defaultFilters.association,
+    );
+  });
+
+  it("Files tab should filter by biospecimen and participant associations", () => {
+    expect(filesContainer.defaultFilters).toEqual({
+      association: ["biospecimen", "participant"],
+    });
+  });
+
+  it("Study Files tab should filter by study association only", () => {
+    expect(studyFilesContainer.defaultFilters).toEqual({
+      association: ["study"],
+    });
+  });
+
+  it("association filters should be mutually exclusive", () => {
+    const filesAssociations = filesContainer.defaultFilters.association;
+    const studyFilesAssociations =
+      studyFilesContainer.defaultFilters.association;
+    const overlap = filesAssociations.filter((value) =>
+      studyFilesAssociations.includes(value),
+    );
+    expect(overlap).toHaveLength(0);
   });
 });

--- a/src/bento/dashboardTabData.test.js
+++ b/src/bento/dashboardTabData.test.js
@@ -35,6 +35,10 @@ describe('Study Files tab configuration', () => {
       expect(studyFilesContainer.dataKey).toBe('data_file_uuid');
     });
 
+    it('should always apply association filter as study', () => {
+      expect(studyFilesContainer.defaultFilters).toEqual({ association: ['study'] });
+    });
+
     it('should have selectableRows enabled', () => {
       expect(studyFilesContainer.selectableRows).toBe(true);
     });
@@ -112,5 +116,22 @@ describe('Study Files tab configuration', () => {
     it('should have correct addAllFilesResponseKeys', () => {
       expect(studyFilesContainer.addAllFilesResponseKeys).toEqual(['studyFileOverview', 'data_file_uuid']);
     });
+  });
+});
+
+describe('Files tab configuration', () => {
+  const filesTab = tabs.find((t) => t.id === 'file_tab');
+  const filesContainer = tabContainers.find((t) => t.id === 'file_tab');
+
+  it('should exist in the tabs array', () => {
+    expect(filesTab).toBeDefined();
+  });
+
+  it('should reference numberOfFiles for count', () => {
+    expect(filesTab.count).toBe('numberOfFiles');
+  });
+
+  it('should always apply association filter as biospecimen and participant', () => {
+    expect(filesContainer.defaultFilters).toEqual({ association: ['biospecimen', 'participant'] });
   });
 });

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -607,6 +607,7 @@ export const table = {
       header: "Participants",
       sort: "asc",
       display: true,
+      cellType: cellTypes.CUSTOM_ELEM,
       tooltipText:
         "For each of the nodes listed below, the number of participants represented by one or more records within that node",
     },
@@ -615,6 +616,7 @@ export const table = {
       header: "Records",
       sort: "asc",
       display: true,
+      cellType: cellTypes.CUSTOM_ELEM,
       tooltipText:
         "For each of the nodes listed below, the total number of records within each node. Participants may have multiple/numerous records within certain nodes",
     },

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -59,10 +59,12 @@ export const studyFilesTooltipContent = {
 // --------------- GraphQL Queries for Study Files Tab ---------------
 
 // Separate query for Study Files Tab with pagination support
+// Uses fileOverview with association filter set to 'study'
 export const GET_STUDY_FILES_QUERY = gql`
-  query studyFileOverview(
+  query fileOverview(
     $study_id: [String]
     $study_short_name: [String]
+    $association: [String]
     $data_file_type: [String]
     $data_file_format: [String]
     $data_file_uuid: [String]
@@ -72,10 +74,11 @@ export const GET_STUDY_FILES_QUERY = gql`
     $order_by: String = "data_file_uuid"
     $sort_direction: String = "asc"
   ) {
-    studyFileOverview(
+    fileOverview(
       study_short_name: $study_short_name
       study_id: $study_id
       study_accession: $study_accession
+      association: $association
       data_file_type: $data_file_type
       data_file_format: $data_file_format
       data_file_uuid: $data_file_uuid
@@ -95,11 +98,13 @@ export const GET_STUDY_FILES_QUERY = gql`
 `;
 
 // Query for adding selected study files to cart
+// Uses fileOverview with association filter set to 'study'
 export const GET_FILE_IDS_FOR_SELECTED_STUDY_FILES = gql`
-  query studyFileAddSelectedToCart(
+  query fileAddSelectedToCart(
     $data_file_uuid: [String]
     $study_id: [String]
     $study_short_name: [String]
+    $association: [String]
     $data_file_type: [String]
     $data_file_format: [String]
     $study_accession: [String]
@@ -108,11 +113,12 @@ export const GET_FILE_IDS_FOR_SELECTED_STUDY_FILES = gql`
     $order_by: String = "data_file_uuid"
     $sort_direction: String = "asc"
   ) {
-    studyFileOverview(
+    fileOverview(
       data_file_uuid: $data_file_uuid
       study_id: $study_id
       study_short_name: $study_short_name
       study_accession: $study_accession
+      association: $association
       data_file_type: $data_file_type
       data_file_format: $data_file_format
       first: $first
@@ -131,7 +137,7 @@ export const studyFilesTableConfig = {
   dataKey: "data_file_uuid",
   buttonText: "Add Selected Files",
   addFilesRequestVariableKey: "data_file_uuid",
-  addFilesResponseKeys: ["studyFileOverview", "data_file_uuid"],
+  addFilesResponseKeys: ["fileOverview", "data_file_uuid"],
   addSelectedFilesQuery: GET_FILE_IDS_FOR_SELECTED_STUDY_FILES,
   tableMsg: {
     noMatch: "No study-level files associated with this study.",

--- a/src/components/PaginatedTable/Customize/CellView.js
+++ b/src/components/PaginatedTable/Customize/CellView.js
@@ -37,6 +37,15 @@ const ClinicalDataDescriptionWrapper = styled('span')(({ $hasNoValues }) => ({
   ...($hasNoValues ? { color: '#AAAAAA' } : { color: '#13344A' }),
 }));
 
+const ClinicalDataCountWrapper = styled('span')(({ $hasNoValues }) => ({
+  fontFamily: 'Nunito',
+  fontSize: '16px',
+  fontWeight: '400',
+  lineHeight: '16px',
+  letterSpacing: '0em',
+  ...($hasNoValues ? { color: '#AAAAAA' } : { color: '#13344A' }),
+}));
+
 const CaseIdLink = (props) => {
   const {
     other_cases: otherCases,
@@ -174,7 +183,11 @@ export const CustomCellView = (props) => {
     case customizeColumn.clinicalDataNode: 
       return <ClinicalDataNodeWrapper $hasNoValues={hasNoValues}>{clinicalDataNode}</ClinicalDataNodeWrapper>
     case customizeColumn.clinicalDataDescription:
-        return <ClinicalDataDescriptionWrapper $hasNoValues={hasNoValues}>{clinicalDataDescription}</ClinicalDataDescriptionWrapper>
+      return <ClinicalDataDescriptionWrapper $hasNoValues={hasNoValues}>{clinicalDataDescription}</ClinicalDataDescriptionWrapper>
+    case customizeColumn.participantCount:
+      return <ClinicalDataCountWrapper $hasNoValues={hasNoValues}>{participantCount}</ClinicalDataCountWrapper>
+    case customizeColumn.recordCount:
+      return <ClinicalDataCountWrapper $hasNoValues={hasNoValues}>{props.recordCount}</ClinicalDataCountWrapper>
     default:
       return (<></>);
   }

--- a/src/components/PaginatedTable/Customize/Types.js
+++ b/src/components/PaginatedTable/Customize/Types.js
@@ -11,6 +11,8 @@ export const customizeColumn = {
   csvDataRow: 'csvDataRow',
   clinicalDataNode: 'clinicalDataNode',
   clinicalDataDescription: 'clinicalDataDescription',
+  participantCount: 'participantCount',
+  recordCount: 'recordCount',
 
   STUDY_CODE: 'study_id',
   ADDITIONAL_CRDC_NODES: 'unique_repository'

--- a/src/pages/dashTemplate/DashTemplateController.js
+++ b/src/pages/dashTemplate/DashTemplateController.js
@@ -78,7 +78,11 @@ const getDashData = (states) => {
       try {
         const result = await client.query({
           query: DASHBOARD_QUERY_NEW,
-          variables: activeFilters,
+          variables: {
+            ...activeFilters,
+            files_association: ['biospecimen', 'participant'],
+            study_association: ['study'],
+          },
         });
 
         if (result.data && result.data.searchParticipants) {
@@ -89,6 +93,8 @@ const getDashData = (states) => {
 
           setDashData({
             ...result.data.searchParticipants,
+            numberOfFiles: result.data?.filesTabCount?.numberOfFiles ?? result.data.searchParticipants.numberOfFiles,
+            numberOfStudyFiles: result.data?.studyFilesTabCount?.numberOfStudyFiles ?? result.data.searchParticipants.numberOfStudyFiles,
             ...targetedTherapyCombination,
             ...filterTargetedTherapyCombination,
           });

--- a/src/pages/dashTemplate/tabs/TabPanel.js
+++ b/src/pages/dashTemplate/tabs/TabPanel.js
@@ -24,6 +24,10 @@ const TabView = (props) => {
     classes,
     activeTab,
   } = props;
+  const mergedActiveFilters = {
+    ...activeFilters,
+    ...config.defaultFilters,
+  };
   /*
   * useReducer table state
   * paginated table update data when state change
@@ -72,14 +76,14 @@ const TabView = (props) => {
         customTheme={customTheme}
         classes={classes}
         section={config.name.replace(/ /g, '_')}
-        activeFilters={activeFilters}
+        activeFilters={mergedActiveFilters}
       >
         <Grid container>
           <Grid item xs={12} id={config.tableID}>
             <TableView
               initState={initTblState}
               themeConfig={themeConfig}
-              queryVariables={activeFilters}
+              queryVariables={mergedActiveFilters}
               totalRowCount={dashboardStats[config.count]}
               activeTab={activeTab}
             />

--- a/src/pages/participantDetail/components/HeaderPanel.js
+++ b/src/pages/participantDetail/components/HeaderPanel.js
@@ -61,6 +61,7 @@ const HeaderPanel = ({ classes, participant }) => {
           <InfoRow classes={classes} label="Race" value={participant.race} />
           <InfoRow classes={classes} label="Ethnicity" value={participant.ethnicity} />
           <InfoRow classes={classes} label="Sex" value={participant.sex} />
+          <InfoRow classes={classes} label="Survival Status" value={participant.survival_status} />
         </div>
 
         {/* Diagnosis */}

--- a/src/pages/participantDetail/components/HeaderPanel.test.js
+++ b/src/pages/participantDetail/components/HeaderPanel.test.js
@@ -96,6 +96,7 @@ describe('HeaderPanel', () => {
         race: 'White',
         ethnicity: 'Not Hispanic',
         sex: 'Male',
+        survival_status: 'Alive',
         primary_diagnosis_disease_group: 'Lymphoma',
         primary_disease_site: 'Chest',
         stage_of_disease: 'Stage II',
@@ -140,6 +141,7 @@ describe('HeaderPanel', () => {
         race: 'Asian',
         ethnicity: 'Hispanic',
         sex: 'Female',
+        survival_status: 'Deceased',
         primary_diagnosis_disease_group: 'Sarcoma',
         primary_disease_site: 'Bone',
         stage_of_disease: 'Stage I',
@@ -169,6 +171,7 @@ describe('HeaderPanel', () => {
         race: 'White',
         ethnicity: 'Not Hispanic',
         sex: 'Male',
+        survival_status: 'Unknown',
         primary_diagnosis_disease_group: 'CML',
         primary_disease_site: 'Blood',
         stage_of_disease: 'Stage II',
@@ -197,6 +200,7 @@ describe('HeaderPanel', () => {
       const participant = {
         participant_id: 'P-5678',
         age_at_enrollment: null, race: null, ethnicity: null, sex: null,
+        survival_status: null,
         primary_diagnosis_disease_group: null, primary_disease_site: null,
         stage_of_disease: null, targeted_therapy: null,
         best_response_to_targeted_therapy: null,
@@ -216,6 +220,7 @@ describe('HeaderPanel', () => {
       const participant = {
         participant_id: 'P-0001',
         age_at_enrollment: 10, race: 'Asian', ethnicity: 'Hispanic', sex: 'Female',
+        survival_status: 'Alive',
         primary_diagnosis_disease_group: 'Leukemia', primary_disease_site: 'Blood',
         stage_of_disease: 'Stage I', targeted_therapy: 'Drug A',
         best_response_to_targeted_therapy: 'Complete Response',
@@ -243,6 +248,7 @@ describe('HeaderPanel', () => {
         race: 'White',
         ethnicity: null,
         sex: 'Male',
+        survival_status: null,
         primary_diagnosis_disease_group: null,
         primary_disease_site: 'Lung',
         stage_of_disease: null,
@@ -253,8 +259,8 @@ describe('HeaderPanel', () => {
       // Act
       renderComponent(participant);
 
-      // Assert – 5 null fields should each render N/A
-      expect(countText('N/A')).toBe(5);
+      // Assert – 6 null fields should each render N/A
+      expect(countText('N/A')).toBe(6);
     });
 
     it('should show N/A when a field value is an empty string', () => {
@@ -265,6 +271,7 @@ describe('HeaderPanel', () => {
         race: '',
         ethnicity: '',
         sex: '',
+        survival_status: '',
         primary_diagnosis_disease_group: '',
         primary_disease_site: '',
         stage_of_disease: '',
@@ -275,8 +282,8 @@ describe('HeaderPanel', () => {
       // Act
       renderComponent(participant);
 
-      // Assert – all 9 info fields should show N/A
-      expect(countText('N/A')).toBe(9);
+      // Assert – all 10 info fields should show N/A
+      expect(countText('N/A')).toBe(10);
     });
 
     it('should show actual values and zero N/A when all fields are populated', () => {
@@ -287,6 +294,7 @@ describe('HeaderPanel', () => {
         race: 'Black',
         ethnicity: 'Not Hispanic',
         sex: 'Female',
+        survival_status: 'Alive',
         primary_diagnosis_disease_group: 'Sarcoma',
         primary_disease_site: 'Bone',
         stage_of_disease: 'Stage III',
@@ -314,6 +322,7 @@ describe('HeaderPanel', () => {
         race: 'White',
         ethnicity: 'Hispanic',
         sex: 'Male',
+        survival_status: 'Deceased',
         primary_diagnosis_disease_group: 'CML',
         primary_disease_site: 'Blood',
         stage_of_disease: 'Stage I',
@@ -337,6 +346,7 @@ describe('HeaderPanel', () => {
         race: '',
         ethnicity: null,
         sex: 'Female',
+        survival_status: null,
         primary_diagnosis_disease_group: 'Leukemia',
         primary_disease_site: '',
         stage_of_disease: null,
@@ -347,9 +357,9 @@ describe('HeaderPanel', () => {
       // Act
       renderComponent(participant);
 
-      // Assert – race(''), ethnicity(null), primary_disease_site(''),
-      // stage_of_disease(null), best_response('') = 5 N/A
-      expect(countText('N/A')).toBe(5);
+      // Assert – race(''), ethnicity(null), survival_status(null), primary_disease_site(''),
+      // stage_of_disease(null), best_response('') = 6 N/A
+      expect(countText('N/A')).toBe(6);
     });
   });
 
@@ -362,6 +372,7 @@ describe('HeaderPanel', () => {
       const participant = {
         participant_id: 'P-SEC',
         age_at_enrollment: 20, race: 'Asian', ethnicity: 'Not Hispanic', sex: 'Female',
+        survival_status: 'Alive',
         primary_diagnosis_disease_group: 'ALL', primary_disease_site: 'Blood',
         stage_of_disease: 'Stage IV', targeted_therapy: 'Drug C',
         best_response_to_targeted_therapy: 'No Response',
@@ -387,6 +398,7 @@ describe('HeaderPanel', () => {
       const participant = {
         participant_id: 'P-LABELS',
         age_at_enrollment: 10, race: 'White', ethnicity: 'Hispanic', sex: 'Male',
+        survival_status: 'Alive',
         primary_diagnosis_disease_group: 'AML', primary_disease_site: 'Bone Marrow',
         stage_of_disease: 'Stage II', targeted_therapy: 'Drug D',
         best_response_to_targeted_therapy: 'Stable Disease',
@@ -401,6 +413,7 @@ describe('HeaderPanel', () => {
         'Race:',
         'Ethnicity:',
         'Sex:',
+        'Survival Status:',
         'Primary Diagnosis:',
         'Primary Disease Site:',
         'Stage of Disease:',

--- a/src/pages/participantDetail/participantDetailController.js
+++ b/src/pages/participantDetail/participantDetailController.js
@@ -74,6 +74,7 @@ const ParticipantDetailController = ({ match }) => {
     participant_id,
     age_at_enrollment: overviewRecord.age_at_enrollment,
     sex: overviewRecord.sex,
+    survival_status: overviewRecord.survival_status,
     race: overviewRecord.race,
     ethnicity: overviewRecord.ethnicity,
     stage_of_disease: overviewRecord.stage_of_disease,

--- a/src/pages/participantDetail/participantDetailController.js
+++ b/src/pages/participantDetail/participantDetailController.js
@@ -7,6 +7,7 @@ import {
   GET_BIOSPECIMENS_OVERVIEW_QUERY,
   GET_FILES_OVERVIEW_QUERY,
   GET_PARTICIPANTS_OVERVIEW_QUERY,
+  defaultFilters,
 } from '../../bento/dashboardTabData';
 
 const ParticipantDetailController = ({ match }) => {
@@ -39,7 +40,7 @@ const ParticipantDetailController = ({ match }) => {
     error: filesError,
     data: filesData,
   } = useQuery(GET_FILES_OVERVIEW_QUERY, {
-    variables: { participant_id: [participant_id] },
+    variables: { participant_id: [participant_id], ...defaultFilters.files },
   });
 
   if (participantLoading || biospecimensLoading || filesLoading) {

--- a/src/pages/studyDetail/views/study-files/StudyFilesView.js
+++ b/src/pages/studyDetail/views/study-files/StudyFilesView.js
@@ -16,6 +16,7 @@ import {
   studyFilesTableConfig,
   GET_STUDY_FILES_QUERY,
 } from "../../../../bento/studyDetailData";
+import { defaultFilters } from "../../../../bento/dashboardTabData";
 import styles from "./StudyFilesStyle";
 
 const initFilesTableState = (initialState) => ({
@@ -39,10 +40,12 @@ const StudyFilesView = ({ classes, study_id }) => {
   const cartState = useSelector((state) => state.cartReducer);
 
   // Fetch all study files once (client-side pagination)
+  // Using fileOverview with association filter from defaultFilters
   const { loading, error, data } = useQuery(GET_STUDY_FILES_QUERY, {
     skip: !study_id,
     variables: {
       study_id: [study_id],
+      association: defaultFilters.studyFiles.association, // Filter to only study-associated files
       first: 10000,
       order_by: studyFilesTableConfig.defaultSortField,
       sort_direction: studyFilesTableConfig.defaultSortDirection,
@@ -50,7 +53,7 @@ const StudyFilesView = ({ classes, study_id }) => {
     fetchPolicy: "cache-first", // Cache the results
   });
 
-  const studyFiles = data?.studyFileOverview || [];
+  const studyFiles = data?.fileOverview || [];
 
   const configuredWrapper = configWrapper(
     studyFilesTableConfig,
@@ -62,6 +65,7 @@ const StudyFilesView = ({ classes, study_id }) => {
   // Active filters for add to cart functionality
   const activeFilters = {
     study_id: [study_id],
+    association: defaultFilters.studyFiles.association, // Include association filter for cart operations
   };
 
   return (


### PR DESCRIPTION
## Study Filtering and File Association Support + Additional Enhancements

This pull request implements comprehensive study-level filtering support across the dashboard, consolidates the Files and Study Files tabs to use a unified backend API with association-based differentiation, and includes several UI/UX improvements.

### 🎯 Core Changes (CTDC-2102)

#### 1. **Study Filtering Support**
- ✅ Added `study_short_name` filter parameter to all major GraphQL queries:
  - `TARGETED_THERAPY_QUERY`
  - `DASHBOARD_QUERY_NEW`
  - `GET_PARTICIPANTS_OVERVIEW_QUERY`
  - `GET_BIOSPECIMENS_OVERVIEW_QUERY`
  - `GET_FILES_OVERVIEW_QUERY`
  - All cart operation queries (participant, biospecimen, and file cart queries)
- ✅ Added Study facet to dashboard with `participantCountByStudyShortName` and `filterParticipantCountByStudyShortName`

#### 2. **Association-Based Tab Counts** 🔄
- **Files Tab**: Uses `association: ['biospecimen', 'participant']` to count only biospecimen/participant-associated files
- **Study Files Tab**: Uses `association: ['study']` to count only study-level files
- Implemented separate GraphQL query aliases (`filesTabCount` and `studyFilesTabCount`) in `DASHBOARD_QUERY_NEW` to provide accurate per-tab counts
- Updated `DashTemplateController.js` to merge association-filtered counts into dashboard statistics

#### 3. **Backend API Consolidation** ⚡
**Breaking architectural change:** Study Files tab now uses the unified `fileOverview` API instead of `studyFileOverview`

**Before:**
- Files tab → `fileOverview` API
- Study Files tab → `studyFileOverview` API (separate endpoint)

**After:**
- Files tab → `fileOverview` API with `association: ['biospecimen', 'participant']`
- Study Files tab → `fileOverview` API with `association: ['study']`

**Benefits:**
- Single backend endpoint handles both file types
- Consistent data model and column structure
- Simplified maintenance and testing

#### 4. **Default Filters Infrastructure** 🛠️
Added `defaultFilters` configuration object:
```javascript
export const defaultFilters = {
  files: { association: ['biospecimen', 'participant'] },
  studyFiles: { association: ['study'] },
};
```

Updated `TabPanel.js` to merge `defaultFilters` with user-applied filters, ensuring tab-specific association filters are always applied regardless of user selections.

#### 5. **Study Files Query Preparation** 🚧
Updated Study Files GraphQL queries with:
- ✅ Active: `study_short_name`, `association` parameters
- 📝 Commented placeholders: All standard facet filters (diagnosis, stage, grade, demographics, biospecimen attributes, etc.)

> **Note:** Placeholder filters are commented out pending backend implementation.

---

### 🆕 Additional Enhancements

#### **CTDC-2155: Clinical Data Table Grey Styling**
- Apply grey styling to Participant Count and Record Count columns when no data available
- Consistent with Definition and Clinical Data Node behavior for disabled columns
- Uses styled components with conditional `$hasNoValues` prop pattern

#### **CTDC-2149: Survival Status Field**
- Added `survival_status` field to Participant Details page
- Field displayed in Demographics section under Sex
- Label shown in all caps: "SURVIVAL STATUS"
- Values pulled from database for each participant
- Updated GraphQL queries, controller mapping, and tests

#### **Nomenclature Consistency**
- Renamed `caseCount` to `participantCount` throughout codebase
- Consistent terminology across all components
- Updated tests and configuration



### 🔗 Backend Dependency

This frontend PR depends on backend PR: [CBIIT/crdc-ctdc-backend#193](https://github.com/CBIIT/crdc-ctdc-backend/pull/193)

**Backend must support:**
- `study_short_name` filter in `searchParticipants`
- `association` parameter in `fileOverview` query
- `filesTabCount` and `studyFilesTabCount` aliased queries
- Study facet counts
- `survival_status` field in participant data

---

### 🚀 Testing Checklist

- [ ] Files tab displays only biospecimen/participant-associated files
- [ ] Study Files tab displays only study-level files
- [ ] Tab counts reflect association-filtered results
- [ ] Study filter (study_short_name) works across all tabs
- [ ] Cart operations respect association filters
- [ ] Clinical Data columns grey out appropriately
- [ ] Survival Status displays on Participant Details page
- [ ] Download All button disabled when no clinical data

```