### PR TITLE
CTDC-2148: Remove file size limitation from document downloads to enable downloads of all file sizes

### DIFF
--- a/src/bento/__tests__/studyDetailData.test.js
+++ b/src/bento/__tests__/studyDetailData.test.js
@@ -133,7 +133,6 @@ describe("studyFilesTableConfig columns", () => {
     expect(accessCol).toBeDefined();
     expect(accessCol.downloadDocument).toBe(true);
     expect(accessCol.documentDownloadProps).toBeDefined();
-    expect(accessCol.documentDownloadProps.maxFileSize).toBe(80000000);
   });
 
   it("has correct document download configuration", () => {

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -4,7 +4,6 @@ import { cellTypes, dataFormatTypes, headerTypes } from '@bento-core/table';
 // import { customCasesTabDownloadCSV, customFilesTabDownloadCSV, customSamplesTabDownloadCSV } from './tableDownloadCSV';
 import downloadSuccess from '../assets/dash/downloadSuccess.svg'
 import downloadLock from '../assets/dash/downloadLock.svg'
-import previewLarge from '../assets/dash/previewLarge.svg'
 
 // --------------- Tooltip configuration --------------
 export const tooltipContent = {
@@ -1382,8 +1381,6 @@ export const tabContainers = [
         cellType: cellTypes.CUSTOM_ELEM,
         downloadDocument: true, // To indicate that column is document donwload
         documentDownloadProps: {
-          // Max file size needs to bin Bytes to seperate two support file preview and download
-          maxFileSize: 80000000, // 10MB => 80,000,000 bits
           // datafield where file file column exists in the table
           fileSizeColumn: 'data_file_size',
           // datafield where file file id exists in the table which is used to get file location
@@ -1395,17 +1392,13 @@ export const tabContainers = [
           // datafield where file name exists
           fileName: 'data_file_name',
 
-          // Case 1: Logged in and granted access, file size below {maxFileSize}
+          // Case 1: Logged in and granted access
           toolTipTextFileDownload: 'Click to download a copy of this file if you have been approved by dbGaP',
           iconFileDownload: downloadSuccess,
           
-          // Case 2: Not logged in or access not granted, file size below {maxFileSize}
+          // Case 2: Not logged in or access not granted
           iconUnauthenticated: downloadLock,
           toolTipTextUnauthenticated: 'You must be logged in and must already have been granted access to download a copy of this file',
-
-          // Case 3: Regardless of login status, file size larger than {maxFileSize}
-          iconFilePreview: previewLarge,
-          toolTipTextFilePreview: 'Because of its size and/or format, this file must be accessed via the My Files workflow',
         },
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
@@ -1529,8 +1522,6 @@ export const tabContainers = [
         cellType: cellTypes.CUSTOM_ELEM,
         downloadDocument: true, // To indicate that column is document download
         documentDownloadProps: {
-          // Max file size needs to be in Bytes to separate two support file preview and download
-          maxFileSize: 80000000, // ~80 MB
           // datafield where file size column exists in the table
           fileSizeColumn: 'data_file_size',
           // datafield where file id exists in the table which is used to get file location
@@ -1542,17 +1533,13 @@ export const tabContainers = [
           // datafield where file name exists
           fileName: 'data_file_name',
 
-          // Case 1: Logged in and granted access, file size below {maxFileSize}
+          // Case 1: Logged in and granted access
           toolTipTextFileDownload: 'Click to download a copy of this file if you have been approved by dbGaP',
           iconFileDownload: downloadSuccess,
 
-          // Case 2: Not logged in or access not granted, file size below {maxFileSize}
+          // Case 2: Not logged in or access not granted
           iconUnauthenticated: downloadLock,
           toolTipTextUnauthenticated: 'You must be logged in and must already have been granted access to download a copy of this file',
-
-          // Case 3: Regardless of login status, file size larger than {maxFileSize}
-          iconFilePreview: previewLarge,
-          toolTipTextFilePreview: 'Because of its size and/or format, this file must be accessed via the My Files workflow',
         },
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -2,7 +2,6 @@ import { cellTypes, dataFormatTypes } from "@bento-core/table";
 import gql from "graphql-tag";
 import downloadSuccess from "../assets/dash/downloadSuccess.svg";
 import downloadLock from "../assets/dash/downloadLock.svg";
-import previewLarge from "../assets/dash/previewLarge.svg";
 
 // --------------- Tooltip configuration --------------
 export const tooltipContent = {
@@ -195,7 +194,6 @@ export const studyFilesTableConfig = {
       cellType: cellTypes.CUSTOM_ELEM,
       downloadDocument: true,
       documentDownloadProps: {
-        maxFileSize: 80000000,
         fileSizeColumn: "data_file_size",
         fileLocationColumn: "data_file_uuid",
         fileFormatColumn: "data_file_format",
@@ -205,9 +203,6 @@ export const studyFilesTableConfig = {
         iconUnauthenticated: downloadLock,
         toolTipTextUnauthenticated:
           "You must be logged in and must have already been granted access to download a copy of this file",
-        iconFilePreview: previewLarge,
-        toolTipTextFilePreview:
-          "Because of its size and/or format, this file must be accessed via the My Files workflow",
       },
       role: cellTypes.DISPLAY,
       tooltipText: "Sort",

--- a/src/components/DocumentDownload/DocumentDownloadView.js
+++ b/src/components/DocumentDownload/DocumentDownloadView.js
@@ -97,12 +97,9 @@ const DocumentDownload = ({
   classes,
   fileSize = 0,
   fileFormat = '',
-  maxFileSize = 200000,
   toolTipTextUnauthenticated = 'Login to access this file',
   toolTipTextFileDownload = 'Click to download a copy of this file if you have been approved by dbGaP',
-  toolTipTextFilePreview = 'Because of its size and/or format, this file is unavailable for download and must be accessed via the My Files workflow',
   iconFileDownload = '',
-  iconFilePreview = '',
   iconUnauthenticated = '',
   fileLocation = '',
   requiredACLs = [],
@@ -163,8 +160,6 @@ const DocumentDownload = ({
   return (
     <>
       <div>
-        {fileSize < maxFileSize && (
-          <>
             {(enableAuthentication && isSignedIn && hasAccess) ? (
               /* ** Case 1: Logged in and granted access, file size below 10MB ** */
               <ToolTip classes={{ tooltip: classes.customTooltip, arrow: classes.customArrow }} title={toolTipTextFileDownload} placement="bottom">
@@ -196,18 +191,7 @@ const DocumentDownload = ({
                 </div>
               </ToolTip>
             )}
-          </>
-        )}
-        { fileSize >= maxFileSize && (
-          /* ** Case 3: Regardless of login status, file size larger than 10MB ** */
-          <ToolTip classes={{ tooltip: classes.customTooltip, arrow: classes.customArrow }} title={toolTipTextFilePreview} placement="bottom">
-            <div
-              style={{ textAlign: 'center' }}
-            >
-              <CustomIcon imgSrc={iconFilePreview} />
-            </div>
-          </ToolTip>
-        )}
+   
         <SessionTimeOutModal
           open={showModal}
           closeModal={closeModal}

--- a/src/components/DocumentDownload/DocumentDownloadView.js
+++ b/src/components/DocumentDownload/DocumentDownloadView.js
@@ -95,7 +95,6 @@ const downloadFile = async (signedUrl, fileName, fileFormat) => {
 // NOTE: This component is getting more complex, will need to refactor at some point.
 const DocumentDownload = ({
   classes,
-  fileSize = 0,
   fileFormat = '',
   toolTipTextUnauthenticated = 'Login to access this file',
   toolTipTextFileDownload = 'Click to download a copy of this file if you have been approved by dbGaP',
@@ -161,7 +160,7 @@ const DocumentDownload = ({
     <>
       <div>
             {(enableAuthentication && isSignedIn && hasAccess) ? (
-              /* ** Case 1: Logged in and granted access, file size below 10MB ** */
+              /* ** Case 1: Logged in and granted access ** */
               <ToolTip classes={{ tooltip: classes.customTooltip, arrow: classes.customArrow }} title={toolTipTextFileDownload} placement="bottom">
                 <div
                   onClick={() => fetchFileToDownload(fileLocation, signOut, setShowModal, fileName, fileFormat, showUnauthorizedNotification)}
@@ -170,7 +169,7 @@ const DocumentDownload = ({
                   <CustomIcon imgSrc={iconFileDownload} />
                 </div>
               </ToolTip>
-            /* ** Case 2: Not logged in or access not granted, file size below 10MB ** */
+            /* ** Case 2: Not logged in or access not granted ** */
             ) : (!isSignedIn) ? (
               // Case 2.1 Not logged in
               <ToolTip classes={{ tooltip: classes.customTooltip, arrow: classes.customArrow }} title={toolTipTextUnauthenticated} placement="bottom">


### PR DESCRIPTION
### Summary
Remove 80MB file size limitation from document downloads to allow downloads of all file sizes.

### Changes
- Removed `maxFileSize` prop (previously set to 80MB/80,000,000 bytes) from `DocumentDownloadView` component
- Removed preview-related props: `iconFilePreview`, `toolTipTextFilePreview`, and `previewLarge` icon
- Updated configurations in `dashboardTabData.js` and `studyDetailData.js`
- Updated tests to remove `maxFileSize` assertions

### Behavior
**Before:** Files ≥80MB showed a preview icon and couldn't be downloaded directly  
**After:** All files can be downloaded (if authenticated and authorized)

### Files Modified
- DocumentDownloadView.js
- dashboardTabData.js
- studyDetailData.js
- studyDetailData.test.js

---

### 📝 Important Unit Distinction (For Future Notes)

The old limit was `maxFileSize: 80000000` **bytes**.

#### Understanding MB vs MiB

- **MB (Megabyte, decimal/SI):** `1 MB = 1,000,000 bytes`  
  → `80,000,000 bytes = 80 MB`

- **MiB (Mebibyte, binary/IEC):** `1 MiB = 1,048,576 bytes`  
  → `80,000,000 bytes ≈ 76.29 MiB`

#### Real-World Example

The `FORMAT_BYTES` formatter divides by **1,048,576** (binary) but labels it "MB":

```javascript
// Database value
data_file_size: 80167493  // bytes

// Browser displays
80167493 ÷ 1,048,576 = 76.45 MB

// Problem with old limit
80,167,493 > 80,000,000  ✓ Would be BLOCKED
But user sees "76.45 MB" < "80 MB"  ✗ Appears OK!
```

**Why this file would have been incorrectly blocked:**
- Database: `80,167,493 bytes` (exceeds 80,000,000)
- Display: `76.45 MB` (looks under "80 MB")
- User confusion: File appears valid but gets blocked

#### Key Takeaway

The `data_file_size` field is in **bytes**. Always validate using bytes, not the formatted "MB" display.

---