### PR TITLE
[CTDC-2170] Fix: Study filter not applied when navigating to Explore page from Study Detail

### DIFF
--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -14,7 +14,7 @@ import TabPanel from "../../components/Tab/TabPanel";
 import Styles from "./studyDetailsStyle";
 import StudyThemeProvider from "./studyDetailsThemeConfig";
 import Overview from "./views/overview/overview";
-import { onClearAllFilters } from "../dashTemplate/sideBar/BentoFilterUtils";
+import { onClearAllAndSelectFacetValue } from "../dashTemplate/sideBar/BentoFilterUtils";
 import useDashboardTabs from "../dashTemplate/components/dashboard-tabs-store";
 import ClinicalDataController from "./views/clinical-data/ClinicalDataController";
 import StudyFilesView from "./views/study-files/StudyFilesView";
@@ -63,7 +63,7 @@ const StudyDetailView = ({
 
   const linkToDashboard = () => {
     // TODO: Once local-find is enabled; dispatch(resetAllData()) from bento-core/local-find to RESET_LOCALFIND_ALL_DATA
-    onClearAllFilters();
+    onClearAllAndSelectFacetValue("study_short_name", study_short_name);
     actions.changeCurrentTab(0);
   };
 

--- a/src/pages/studyDetail/views/overview/components/BiospecimenProfile/BiospecimenProfile.js
+++ b/src/pages/studyDetail/views/overview/components/BiospecimenProfile/BiospecimenProfile.js
@@ -30,7 +30,7 @@ import {
   // StyledTabs,
 } from "./biospecimen-profile-styled.js";
 import useDashboardTabs from "../../../../../dashTemplate/components/dashboard-tabs-store.js";
-import { onClearAllFilters } from "../../../../../dashTemplate/sideBar/BentoFilterUtils.js";
+import { onClearAllAndSelectFacetValue } from "../../../../../dashTemplate/sideBar/BentoFilterUtils.js";
 
 const tooltipContent = ({ argument, originalValue }) => (
   <div>
@@ -61,7 +61,7 @@ const BiospecimenProfile = ({ classes, data, studyShortName, studyId }) => {
 
   const linkToDashboard = () => {
     // TODO: Once local-find is enabled; dispatch(resetAllData()) from bento-core/local-find to RESET_LOCALFIND_ALL_DATA
-    onClearAllFilters();
+    onClearAllAndSelectFacetValue('study_short_name', studyShortName);
     actions.changeCurrentTab(1);
   };
 

--- a/src/pages/studyDetail/views/overview/components/BiospecimenProfile/biospecimen-profile-modal.js
+++ b/src/pages/studyDetail/views/overview/components/BiospecimenProfile/biospecimen-profile-modal.js
@@ -22,7 +22,7 @@ import {
   StyledLink,
 } from "./biospecimen-profile-modal-styled.js";
 import useDashboardTabs from "../../../../../dashTemplate/components/dashboard-tabs-store.js";
-import { onClearAllFilters } from "../../../../../dashTemplate/sideBar/BentoFilterUtils.js";
+import { onClearAllAndSelectFacetValue } from "../../../../../dashTemplate/sideBar/BentoFilterUtils.js";
 
 const tabLabels = ["Timepoint", "Biospecimens"];
 
@@ -49,11 +49,10 @@ const BiospecimenProfileModal = ({
   const linkToDashboard = async () => {
     setIsModalOpen(false);
     /*
-      onClearAllFilters() - Clears all selected filters on the Dashboard page.
-      navigatedToDashboard(filterStudy) - Clears all selected filters and selects a study.
-        This will take effect once CTDC supports multiple studies.
+      onClearAllAndSelectFacetValue() - Clears all selected filters and selects a study filter.
+        This applies the study filter when navigating to the Explore page.
     */
-    onClearAllFilters();
+    onClearAllAndSelectFacetValue('study_short_name', studyShortName);
     actions.changeCurrentTab(1);
   };
 


### PR DESCRIPTION
## Description
Fixes issue where the Study filter was not being automatically applied when users navigated to the Explore page by clicking the Participant or Biospecimen count hyperlinks from the Study Detail page.

## Issue
[CTDC-2170](https://tracker.nci.nih.gov/browse/CTDC-2170) - Study filter is not applied when navigating to the Explore page from the Participant and Biospecimen count hyperlinks

## Changes
- Modified navigation behavior to apply study filter based on `study_short_name`
- Updated three navigation points:
  - Associated Participants hyperlink (Study Detail header)
  - Associated Biospecimens hyperlink (Overview tab)
  - Associated Biospecimens hyperlink (Expanded modal view)

## Implementation
Replaced `onClearAllFilters()` with `onClearAllAndSelectFacetValue('study_short_name', studyShortName)` to ensure the study filter is automatically selected when users navigate to the Explore page.

## Testing
- Verified no compilation errors
- Manual testing recommended: Navigate from Study Detail → click Participant/Biospecimen counts → verify study filter is applied on Explore page