### PR TITLE
CTDC-2175: Fix Additional CRDC Nodes to display only data associated with the correct study

### DIFF
--- a/src/pages/studies/studiesController.js
+++ b/src/pages/studies/studiesController.js
@@ -35,16 +35,24 @@ const studiesContainer = () => {
   }
 
   // Transform and combine data
+  const interOpStudiesMap = (interOpData?.getInteropData || []).reduce((acc, entry) => {
+    const s = entry?.data?.getAllStudies;
+    if (s?.study_id) acc[s.study_id] = s;
+    return acc;
+  }, {});
+  console.log('|| interOpStudiesMap', interOpStudiesMap);
+  console.log('|| data', data);
   const updatedData = {
     ...data,
-    getAllStudies: data?.getAllStudies?.map((study) => ({
-      ...study,
-      numberOfPublications: 0, // TODO: Fetch this value from the backend API when it's implemented
-      image_collection:
-        interOpData?.getInteropData?.[0]?.data?.getAllStudies?.image_collection || [],
-      unique_repository:
-        interOpData?.getInteropData?.[0]?.data?.getAllStudies?.unique_repository || [],
-    })),
+    getAllStudies: data?.getAllStudies?.map((study) => {
+      const interOpStudy = interOpStudiesMap[study.study_id];
+      return {
+        ...study,
+        numberOfPublications: 0, // TODO: Fetch this value from the backend API when it's implemented
+        image_collection: interOpStudy?.image_collection || [],
+        unique_repository: interOpStudy?.unique_repository || [],
+      };
+    }),
   };
   
   // Render the Studies component

--- a/src/pages/studies/studiesController.js
+++ b/src/pages/studies/studiesController.js
@@ -40,8 +40,6 @@ const studiesContainer = () => {
     if (s?.study_id) acc[s.study_id] = s;
     return acc;
   }, {});
-  console.log('|| interOpStudiesMap', interOpStudiesMap);
-  console.log('|| data', data);
   const updatedData = {
     ...data,
     getAllStudies: data?.getAllStudies?.map((study) => {


### PR DESCRIPTION
This pull request updates how interoperability data is merged with study data in the `studiesController.js` file. The main improvement is that it now correctly associates each study with its corresponding interoperability data, rather than using only the first entry for all studies.

Data transformation improvements:

* Refactored the logic to build an `interOpStudiesMap` keyed by `study_id`, ensuring each study merges with the correct interoperability data.
* Updated the mapping of `getAllStudies` to fetch `image_collection` and `unique_repository` from the matched entry in `interOpStudiesMap`, instead of always using the first entry from `interOpData`.